### PR TITLE
Configuration: CLIQZ visiblility based on pref

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -11,6 +11,8 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyServiceGetter(this, "uuid",
     "@mozilla.org/uuid-generator;1", "nsIUUIDGenerator");
 
+let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
+
 function hide(element) {
   if (element) {
     element.setAttribute("hidden", "true");
@@ -254,11 +256,31 @@ writeFile('userChrome.css', `
   }
 `);
 
+try {
+  prefs.getBoolPref("extensions.cliqz.listed");
+} catch (e) {
+  // setting default
+  prefs.setBoolPref("extensions.cliqz.listed", false);
+}
+
+function addonsStyle() {
+  if ( prefs.getBoolPref('extensions.cliqz.listed') ) {
+    return '';
+  } else {
+    return `
+      .addon[value="cliqz@cliqz.com"] {
+        display: none !important;
+      }
+    `;
+  }
+}
+
 writeFile('userContent.css', `
   @-moz-document url-prefix(about:addons) {
     #category-theme {
       display: none !important;
     }
+    ${addonsStyle()}
   }
   @-moz-document url-prefix(about:privatebrowsing) {
     #learnMore {

--- a/mozilla-release/toolkit/mozapps/extensions/content/extensions.css
+++ b/mozilla-release/toolkit/mozapps/extensions/content/extensions.css
@@ -35,9 +35,6 @@ xhtml|link {
   -moz-binding: url("chrome://mozapps/content/extensions/extensions.xml#addon-uninstalled");
 }
 
-.addon[value="cliqz@cliqz.com"] {
-  display: none;
-}
 
 .creator {
   -moz-binding: url("chrome://mozapps/content/extensions/extensions.xml#creator-link");


### PR DESCRIPTION
For debugging purposes we add a pref:
`extensions.cliqz.listed` that control extension visibility on addons
list. On pref change restart is required.