### PR TITLE
BROWSER-75: on Win10 show "openas" dialog

### DIFF
--- a/mozilla-release/browser/components/shell/nsWindowsShellService.cpp
+++ b/mozilla-release/browser/components/shell/nsWindowsShellService.cpp
@@ -958,7 +958,7 @@ nsWindowsShellService::SetDefaultBrowser(bool aClaimAllTypes, bool aForAllUsers)
       // Windows 10 blocks attempts to load the
       // HTTP Handler association dialog.
       if (IsWin10OrLater()) {
-        rv = LaunchModernSettingsDialogDefaultApps();
+        rv = InvokeHTTPOpenAsVerb();
       } else {
         rv = LaunchHTTPHandlerPane();
       }
@@ -966,7 +966,12 @@ nsWindowsShellService::SetDefaultBrowser(bool aClaimAllTypes, bool aForAllUsers)
       // The above call should never really fail, but just in case
       // fall back to showing control panel for all defaults
       if (NS_FAILED(rv)) {
-        rv = LaunchControlPanelDefaultsSelectionUI();
+        if (IsWin10OrLater()) {
+          rv = LaunchModernSettingsDialogDefaultApps();
+        }
+        else {
+          rv = LaunchControlPanelDefaultsSelectionUI();
+        }
       }
       bool isDefault;
       SaveWin8RegistryHashes(aClaimAllTypes, &isDefault);


### PR DESCRIPTION
When trying to set browser default in Win10 let's show system dialog "open with" instead of open Settings menu.

Original FF had this in 40-th version, so for now we just turn it on back in our build.
Commit in original FF: https://hg.mozilla.org/mozilla-central/rev/03f47dc4ada5

We need our own webpage with info, how to set browser default in Win10. Now if user choose another browser in list - this selected browser will open https://support.mozilla.org/1/firefox/43.0.3/WINNT/en-US/win-10-default-browser (which doesn't exist). We can use https://support.mozilla.org/en-US/kb/how-change-your-default-browser-windows-10 as template for such webpage.