### PR TITLE
Autoconfig: install CLIQZ extension on startup

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -11,7 +11,33 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyServiceGetter(this, "uuid",
     "@mozilla.org/uuid-generator;1", "nsIUUIDGenerator");
 
+let extensionUrls = {
+  'release': 'https://s3.amazonaws.com/cdncliqz/update/browser/latest.xpi',
+  'beta': 'https://s3.amazonaws.com/cdncliqz/update/beta/latest.xpi'
+};
+
 let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
+
+function updateCliqzVersion() {
+  Cu.import("resource://gre/modules/AddonManager.jsm");
+
+  let versionChecker = Cc["@mozilla.org/xpcom/version-comparator;1"]
+                         .getService(Components.interfaces.nsIVersionComparator),
+      channel = prefs.getCharPref("app.update.channel"),
+      url = extensionUrls[channel],
+      addons = JSON.parse(prefs.getCharPref("extensions.bootstrappedAddons")),
+      cliqzAddon = addons['cliqz@cliqz.com'];
+
+  if ( !cliqzAddon || versionChecker.compare(cliqzAddon.version, '1.2.0') < 0 ) {
+    try {
+      AddonManager.getInstallForURL(url, function(addonInstall) {
+        addonInstall.install();
+      }, "application/x-xpinstall");
+    } catch (e) {
+      // Failed to install CLIQZ
+    }
+  }
+}
 
 function hide(element) {
   if (element) {
@@ -198,11 +224,15 @@ var observer = {
         for (var i=0; i < aboutFactories.length; i++)
           registrar.unregisterFactory(aboutFactories[i].classID, aboutFactories[i].factory);
         break;
+      case "final-ui-startup":
+        updateCliqzVersion();
+        break;
     }
   }
 };
 Services.obs.addObserver(observer, "chrome-document-global-created", false);
 Services.obs.addObserver(observer, "quit-application", false);
+Services.obs.addObserver(observer, "final-ui-startup", false);
 // Disable Sync - end
 
 CustomizableUI.destroyWidget("pocket-button");


### PR DESCRIPTION
In case CLIQZ extension is outdated or not-present, autoconfig should install it before browser open first window. 

Most important use case is to update to signed extension if browser requires XPI signing. 