### PR TITLE
Quickfix: help menu - createQbutton API change

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -53,7 +53,7 @@ function E(id, context) {
 function disableAbout(aClass, aClassName, aboutType) {
   var gAbout = {
     newChannel : function (aURI) {
-      var url = "data:text/html," + gAboutXHTML;
+      var url = "data:text/html,";
       var channel = Services.io.newChannel(url, null, null);
       channel.originalURI = aURI;
       return channel;
@@ -184,7 +184,7 @@ function alternateHelpMenu(doc) {
     }
 
     var cliqzButton = doc.createElement('toolbarbutton');
-    doc.defaultView.CLIQZ.Core.createQbutton(doc.defaultView, cliqzButton);
+    doc.defaultView.CLIQZ.Core.createQbutton(cliqzButton);
 
     var helpMenu = E("menu_HelpPopup", doc);
     var list = cliqzButton.children;


### PR DESCRIPTION
Entire feature is just a dirty hack. Autoconfig should not rely on
extension APIs as we cannot guarantee those will not change over time.
We should move entire feature into Firefox codebase.

Fixing: #130