### PR TITLE
DB-98: Fixed bug in magic build script argument parser

### DIFF
--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -17,7 +17,7 @@ set -x
 VERBOSE=false
 CLOBBER=false
 
-while [[ $# > 1 ]]
+while [[ $# > 0 ]]
 do
   key="$1"
 


### PR DESCRIPTION
Fix argument parser (--clobber should now work).