### PR TITLE
DB-98: fix bug in FF configuration script with locale processing

### DIFF
--- a/mozilla-release/configure.in
+++ b/mozilla-release/configure.in
@@ -3728,7 +3728,6 @@ MOZ_HELP_VIEWER=
 MOZ_SPELLCHECK=1
 MOZ_ANDROID_APZ=
 MOZ_TOOLKIT_SEARCH=1
-MOZ_UI_LOCALE=en-US
 MOZ_UNIVERSALCHARDET=1
 MOZ_URL_CLASSIFIER=
 MOZ_XUL=1
@@ -4537,6 +4536,11 @@ MOZ_ARG_ENABLE_STRING(ui-locale,
 [  --enable-ui-locale=ab-CD
                           Select the user interface locale (default: en-US)],
     MOZ_UI_LOCALE=$enableval )
+
+if test -z "$MOZ_UI_LOCALE"; then
+  MOZ_UI_LOCALE=en-US
+fi
+
 AC_SUBST(MOZ_UI_LOCALE)
 
 AC_SUBST(MOZ_OFFICIAL_BRANDING)


### PR DESCRIPTION
It's look like possible to use two different ways to set up a locale for building - MOZ_UI_LOCALE environment variable or with mozconfig file with --enable-ui-locale option. In real - MOZ_UI_LOCALE always set up in configure.in, so it's only one way to change it - with mozconfig file. Which looks wrong. Here we make changes in configure.in script so now it's possible to set up language correctly in both different way.

ps. looks like js/src/configure.in have similar problem, but it don't used in our build now
pps. may be we can push this commit to original FF