### PR TITLE
DB-365: Homepage preference is reset after restart

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -263,9 +263,6 @@ lockPref("toolkit.startup.max_resumed_crashes", -1);
 // Disable Slow Startup message
 lockPref("browser.slowStartup.notificationDisabled", true);
 
-// Sets default homepage
-pref("browser.startup.homepage", "about:cliqz");
-
 function writeFile(fileName, content) {
   var profileDir = Services.dirsvc.get("ProfD", Ci.nsILocalFile);
 

--- a/mozilla-release/browser/branding/cliqz/locales/browserconfig.properties
+++ b/mozilla-release/browser/branding/cliqz/locales/browserconfig.properties
@@ -3,4 +3,4 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 # Do NOT localize or otherwise change these values
-browser.startup.homepage=about:home
+browser.startup.homepage=about:cliqz


### PR DESCRIPTION
This preference default value is already set in `browser/app/profile/firefox.js`, value is taken from browserconfig.properties.