### PR TITLE
DB-372: improve digital signing script on Windows

### DIFF
--- a/sign_win.bat
+++ b/sign_win.bat
@@ -1,3 +1,4 @@
+@echo off
 cd %CQZ_WORKSPACE%\obj
 
 set ff_version=''
@@ -15,44 +16,19 @@ set timestamp_server=http://timestamp.geotrust.com/tsa
 
 echo %CLZ_SIGNTOOL_PATH%
 
-for %%f in (
-  pkg\core\CLIQZ.exe,
-  pkg\core\crashreporter.exe,
-  pkg\core\maintenanceservice.exe,
-  pkg\core\maintenanceservice_installer.exe,
-  pkg\core\plugin-container.exe,
-  pkg\core\plugin-hang-ui.exe,
-  pkg\core\uninstall\helper.exe,
-  pkg\core\updater.exe,
-  pkg\core\webapp-uninstaller.exe,
-  pkg\core\webapprt-stub.exe,
-  pkg\core\wow_helper.exe,
-  pkg\setup.exe,
-  pkg\core\AccessibleMarshal.dll,
-  pkg\core\breakpadinjector.dll,
-  pkg\core\browser\components\browsercomps.dll,
-  pkg\core\freebl3.dll,
-  pkg\core\gmp-clearkey\0.1\clearkey.dll,
-  pkg\core\icudt52.dll,
-  pkg\core\icuin52.dll,
-  pkg\core\icuuc52.dll,
-  pkg\core\libEGL.dll,
-  pkg\core\libGLESv2.dll,
-  pkg\core\mozalloc.dll,
-  pkg\core\mozglue.dll,
-  pkg\core\nss3.dll,
-  pkg\core\nssckbi.dll,
-  pkg\core\nssdbm3.dll,
-  pkg\core\sandboxbroker.dll,
-  pkg\core\softokn3.dll,
-  pkg\core\xul.dll,
-) do (
-  "%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% %%f
-  "%CLZ_SIGNTOOL_PATH%" verify /pa %%f
-  if NOT %ERRORLEVEL%==0 exit /b 1
-)
-
 cd pkg
+for /R %%f in (
+  *.exe *.dll
+) do (
+  rem Check does file already have a digital sign. If not - try to create one
+  echo Check and sign %%f
+  "%CLZ_SIGNTOOL_PATH%" verify /pa %%f
+  if ERRORLEVEL 1 (
+    "%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% %%f
+    "%CLZ_SIGNTOOL_PATH%" verify /pa %%f
+  )
+  if ERRORLEVEL 1 (goto :error)
+)
 
 del installer.7z
 %archivator_exe% a -r -t7z installer.7z -mx -m0=BCJ2 -m1=LZMA:d25 -m2=LZMA:d19 -m3=LZMA:d1 -mb0:1 -mb0s1:2 -mb0s2:3
@@ -61,4 +37,9 @@ copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\i
 
 "%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 "%CLZ_SIGNTOOL_PATH%" verify /pa dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
-exit /b %ERRORLEVEL%
+if ERRORLEVEL 1 (goto :error)
+
+goto:eof
+
+:error
+exit /b 1


### PR DESCRIPTION
Now works with all *.exe and *.dll files in installer. Also check does file have been signed before or not. And fix an error handling (work with ERRORLEVEL in windows batch script is tricky, https://support.microsoft.com/en-us/kb/39585)