### PR TITLE
DB-372: make DualSigning on windows

### DIFF
--- a/sign_win.bat
+++ b/sign_win.bat
@@ -10,7 +10,8 @@ if NOT "%lang%" == "" set ff_exe=%ff_version%.%lang%
 echo %ff_exe%
 echo %lang%
 
-set timestamp_server=http://timestamp.geotrust.com/tsa
+set timestamp_server_sha1=http://timestamp.verisign.com/scripts/timstamp.dll
+set timestamp_server_sha256=http://timestamp.geotrust.com/tsa
 
 %archivator_exe% x -opkg -y dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 
@@ -24,7 +25,8 @@ for /R %%f in (
   echo Check and sign %%f
   "%CLZ_SIGNTOOL_PATH%" verify /pa %%f
   if ERRORLEVEL 1 (
-    "%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% %%f
+    "%CLZ_SIGNTOOL_PATH%" sign /t %timestamp_server_sha1% /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% %%f
+    "%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server_sha256% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% /as %%f
     "%CLZ_SIGNTOOL_PATH%" verify /pa %%f
   )
   if ERRORLEVEL 1 (goto :error)
@@ -35,7 +37,8 @@ del installer.7z
 cd ..
 copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\instgen\app.tag + pkg\installer.7z dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 
-"%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
+"%CLZ_SIGNTOOL_PATH%" sign /t %timestamp_server_sha1% /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
+"%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server_sha256% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% /as dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 "%CLZ_SIGNTOOL_PATH%" verify /pa dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 if ERRORLEVEL 1 (goto :error)
 


### PR DESCRIPTION
Binaries must be signed twice - with sha1 and sha256 (for normal work on WinXP SP3 and Win10)