### PR TITLE
Update sign_mac.sh

### DIFF
--- a/sign_mac.sh
+++ b/sign_mac.sh
@@ -14,11 +14,16 @@ do
   for app in $PKG_DIR/*.app
   do
     codesign -s $CQZ_CERT_NAME --force --deep $app
+    if [ $? -ne 0 ]; then
+      echo "Something went wrong during signing"
+      exit 1
+    fi
   done
   hdiutil detach /Volumes/CLIQZ
   SIGNED_DMG="${DMG%.dmg}-signed.dmg"
   appdmg CLIQZ-dmg.json $SIGNED_DMG
-  mv $SIGNED_DMG $DMG
+  echo "Replaced unsigned dmg with signed one"
+  cp -v $SIGNED_DMG $DMG
 done
 
 cd $OLDPWD


### PR DESCRIPTION
There is a problem in signing process. Somehow the DMG that we generate hosts unsigned app. 
CLIQZ.app in pkg folder is signed properly.