### PR TITLE
DB-396: Fixed tab restore deduplication

### DIFF
--- a/mozilla-release/browser/components/sessionstore/SessionStore.jsm
+++ b/mozilla-release/browser/components/sessionstore/SessionStore.jsm
@@ -2641,9 +2641,13 @@ var SessionStoreInternal = {
     if (!overwriteTabs) {
       let homePages = aWindow.gHomeButton.getHomePage().split("|");
       winData.tabs = winData.tabs.filter(function (tabData) {
-        if (!tabData.entries || !tabData.entries.length)
+        if (!tabData.entries || !tabData.entries.length) {
           return true;
-        return homePages.indexOf(tabData.entries[0].url) == -1;
+        }
+        let entryIndex = (tabData.index || 1) - 1;  // It's 1-based.
+        let entry = tabData.entries[entryIndex] ||
+          tabData.entries[tabData.entries.length - 1];
+        return homePages.indexOf(entry.url) == -1;
       });
     }
 


### PR DESCRIPTION
When we deduplicated tabs to avoid multiple start pages, we looked at
first url in tab's navigation chain. Instead, we should look at the
one user finished with (usually last in the chain), or the last one.