### PR TITLE
DB-410: Duplicate notification line on addons internal page

### DIFF
--- a/mozilla-release/toolkit/mozapps/extensions/content/extensions.xul
+++ b/mozilla-release/toolkit/mozapps/extensions/content/extensions.xul
@@ -124,7 +124,6 @@
     <key id="focusSearch" key="&search.commandkey;" modifiers="accel"
          command="cmd_focusSearch"/>
   </keyset>
-    <label value="&cliqz.firefoxAddons;"/>
   <hbox flex="1">
     <vbox>
       <hbox id="nav-header"


### PR DESCRIPTION
Probably was introduced by the recent rewrite of git history.