### PR TITLE
Build fix: mac universal builds upload signed version

### DIFF
--- a/magic_upload_files.sh
+++ b/magic_upload_files.sh
@@ -75,7 +75,7 @@ fi
 cd $OBJ_DIR
 
 echo '***** Uploading MAR and package files *****'
-$MAKE automation/build
+$MAKE upload
 
 echo '***** Genereting build_properties.json *****'
 $OLDPWD/mozilla-release/build/gen_build_properties.py


### PR DESCRIPTION
We incorrectly run entire automation/build while only upload step was required. 
Not really sure why it was working before.