### PR TITLE
Build: Encapsulating shared part of magic scripts

### DIFF
--- a/cliqz_env.sh
+++ b/cliqz_env.sh
@@ -1,0 +1,78 @@
+VERBOSE=false
+CLOBBER=false
+
+if [ -z "$LANG" ]; then
+  LANG='en-US'
+fi
+
+while [[ $# > 0 ]]
+do
+  key="$1"
+
+  case $key in
+    -lang|--language)
+    LANG="$2"
+    shift # Consume additional argument
+    ;;
+
+    -v|--verbose)
+    VERBOSE=true
+    ;;
+
+    --clobber)
+    CLOBBER=true
+    ;;
+
+    *)
+    echo "WARNING: Unknown option $key"
+    ;;
+  esac
+  shift # Consume current argument
+done
+
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+  IS_LINUX=true
+  echo 'Linux OS detected'
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  IS_MAC_OS=true
+  echo 'Mac OS detected'
+elif [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
+  IS_WIN=true
+  echo 'Windows OS detected'
+else
+  echo 'Unknow OS -`$OSTYPE`'
+fi
+
+if [ $IS_WIN ]; then
+  MAKE=mozmake
+else
+  MAKE=make
+fi
+
+# TODO: Use MOZ_UPDATE_CHANNEL.
+if [ -z $CQZ_RELEASE_CHANNEL ]; then
+  CQZ_RELEASE_CHANNEL=release
+fi
+
+export MOZCONFIG=browser/config/cliqz-release.mozconfig
+SRC_BASE=mozilla-release
+export MOZ_OBJDIR=../obj
+
+# Mac specific paths
+I386DIR=$MOZ_OBJDIR/i386
+X86_64DIR=$MOZ_OBJDIR/x86_64
+
+export MOZCONFIG=browser/config/cliqz-release.mozconfig
+export CQZ_VERSION=$(awk -F "=" '/version/ {print $2}'\
+  ./repack/distribution/distribution.ini | head -n1)
+export CQZ_UI_LOCALE=`echo $LANG`
+export MOZ_AUTOMATION_UPLOAD=1
+export CQZ_BALROG_DOMAIN=balrog-admin.10e99.net
+export BALROG_PATH=../build-tools/scripts/updates
+export S3_BUCKET=repository.cliqz.com
+export S3_UPLOAD_PATH=`echo dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/${LANG:0:2}`
+
+OBJ_DIR=obj
+if [ $IS_MAC_OS ]; then
+  OBJ_DIR=$OBJ_DIR/i386
+fi

--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -14,52 +14,7 @@
 set -e
 set -x
 
-VERBOSE=false
-CLOBBER=false
-
-while [[ $# > 0 ]]
-do
-  key="$1"
-
-  case $key in
-    -lang|--language)
-    LANG="$2"
-    shift # Consume additional argument
-    ;;
-
-    -v|--verbose)
-    VERBOSE=true
-    ;;
-
-    --clobber)
-    CLOBBER=true
-    ;;
-
-    *)
-    echo "WARNING: Unknown option $key"
-    ;;
-  esac
-  shift # Consume current argument
-done
-
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-  IS_LINUX=true
-  echo 'Linux OS detected'
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-  IS_MAC_OS=true
-  echo 'Mac OS detected'
-elif [[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]]; then
-  IS_WIN=true
-  echo 'Windows OS detected'
-else
-  echo 'Unknow OS -`$OSTYPE`'
-fi
-
-export MOZCONFIG=browser/config/cliqz-release.mozconfig
-SRC_BASE=mozilla-release
-export MOZ_OBJDIR=../obj
-I386DIR=$MOZ_OBJDIR/i386
-X86_64DIR=$MOZ_OBJDIR/x86_64
+source cliqz_env.sh
 
 cd $SRC_BASE
 

--- a/magic_upload_files.sh
+++ b/magic_upload_files.sh
@@ -4,81 +4,18 @@
 set -e
 set -x
 
-if [ -z "$LANG" ]; then
-  LANG='en-US'
-fi
-VERBOSE=false #TODO
+source cliqz_env.sh
 
-while [[ $# > 1 ]]
-do
-    key="$1"
-
-    case $key in
-        -lang|--language)
-        LANG="$2"
-        shift # past argument
-        ;;
-        -v|--verbose)
-        VERBOSE=true
-        ;;
-        *)
-        echo "unknown option $key"
-        exit
-        ;;
-    esac
-    shift # past argument or value
-done
-
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    export IS_LINUX=true
-    echo 'Linux OS detected'
-elif [[ "$OSTYPE" == "darwin"* ]]; then
-    export IS_MAC_OS=true
-    echo 'MAC OS detected'
-elif [[ "$OSTYPE" == "cygwin" ]]; then
-    export IS_WIN=true
-    echo 'WINDOWS OS detected'
-elif [[ "$OSTYPE" == "msys" ]]; then
-    export IS_WIN=true
-    echo 'WINDOWS OS detected'
-else
-    echo 'Unknow OS -`$OSTYPE`'
-fi
-
-# TODO: Use MOZ_UPDATE_CHANNEL.
-if [ -z $CQZ_RELEASE_CHANNEL ]; then
-  CQZ_RELEASE_CHANNEL=release
-fi
-
-if [ $IS_WIN ]; then
-  MAKE=mozmake
-else
-  MAKE=make
-fi
+cd $OBJ_DIR
 
 echo "Starting build on with language $LANG and VERBOSE=$VERBOSE"
-
-export MOZCONFIG=browser/config/cliqz-release.mozconfig
-export CQZ_VERSION=$(awk -F "=" '/version/ {print $2}'\
-  ./repack/distribution/distribution.ini | head -n1)
-export CQZ_UI_LOCALE=`echo $LANG`
-export MOZ_AUTOMATION_UPLOAD=1
-export CQZ_BALROG_DOMAIN=balrog-admin.10e99.net
-export BALROG_PATH=../build-tools/scripts/updates
-export S3_BUCKET=repository.cliqz.com
-export S3_UPLOAD_PATH=`echo dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/${LANG:0:2}`
-
-OBJ_DIR=obj
-if [ $IS_MAC_OS ]; then
-  OBJ_DIR=$OBJ_DIR/i386
-fi
-cd $OBJ_DIR
 
 echo '***** Uploading MAR and package files *****'
 $MAKE upload
 
 echo '***** Genereting build_properties.json *****'
 $OLDPWD/mozilla-release/build/gen_build_properties.py
+
 cd $OLDPWD
 
 echo '***** Submiting to Balrog *****'


### PR DESCRIPTION
For developers convinience we can just:
`source cliqz_env.sh`
to have all environment variables set.