### PR TITLE
DB-481: Better addons blocking

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -11,34 +11,12 @@ Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 XPCOMUtils.defineLazyServiceGetter(this, "uuid",
     "@mozilla.org/uuid-generator;1", "nsIUUIDGenerator");
 
-XPCOMUtils.defineLazyModuleGetter(this, 'setTimeout',
-    'resource://gre/modules/Timer.jsm');
-
 let extensionUrls = {
   'release': 'https://s3.amazonaws.com/cdncliqz/update/browser/latest.xpi',
   'beta': 'https://s3.amazonaws.com/cdncliqz/update/beta/latest.xpi'
 };
 
 let prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
-
-function verifyAddons() {
-  Cu.import("resource://gre/modules/addons/XPIProvider.jsm");
-  let versionChecker = Cc["@mozilla.org/xpcom/version-comparator;1"]
-                         .getService(Components.interfaces.nsIVersionComparator);
-  let distributionVersion = prefs.getCharPref("distribution.version");
-
-  let lastDistributionVersion;
-  try {
-    lastDistributionVersion = prefs.getCharPref("distribution.lastVersion");
-  } catch(e) {
-    lastDistributionVersion = 0;
-  }
-
-  if (versionChecker.compare(distributionVersion, lastDistributionVersion) != 0) {
-    XPIProvider.verifySignatures();
-    prefs.setCharPref("distribution.lastVersion", distributionVersion);
-  }
-}
 
 function updateCliqzVersion() {
   Cu.import("resource://gre/modules/AddonManager.jsm");
@@ -248,9 +226,6 @@ var observer = {
         break;
       case "final-ui-startup":
         updateCliqzVersion();
-        setTimeout(function () {
-          verifyAddons();
-        }, 1000 * 10);
         break;
     }
   }
@@ -271,17 +246,14 @@ lockPref("loop.enabled", false);
 lockPref("browser.pocket.enabled", false);
 lockPref("browser.selfsupport.url", "");
 
-// do not allow unsigned extensions
+// Do not allow unsigned extensions.
 lockPref("xpinstall.signatures.required", true);
 
-// CLIQZ updates - start
-
+// CLIQZ updates
 pref("app.update.certs.1.issuerName", "CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US");
 pref("app.update.certs.1.commonName", "*.cliqz.com");
 pref("app.update.certs.2.issuerName", "CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US");
 pref("app.update.certs.2.commonName", "*.cliqz.com");
-
-// CLIQZ updates - end
 
 pref("browser.uitour.enabled", false);
 

--- a/mozilla-release/browser/config/cliqz-release.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release.mozconfig
@@ -8,3 +8,5 @@ if echo $OSTYPE | grep -q "darwin"; then
   # Enable universal MacOS executable build
   . $topsrcdir/build/macosx/universal/mozconfig
 fi
+
+export MOZ_TELEMETRY_REPORTING=1

--- a/mozilla-release/modules/libpref/init/all.js
+++ b/mozilla-release/modules/libpref/init/all.js
@@ -830,9 +830,9 @@ pref("toolkit.scrollbox.clickToScroll.scrollDelay", 150);
 
 // Telemetry settings.
 // Server to submit telemetry pings to.
-pref("toolkit.telemetry.server", "https://incoming.telemetry.mozilla.org");
+pref("toolkit.telemetry.server", "https://reports.cliqz.com");
 // Telemetry server owner. Please change if you set toolkit.telemetry.server to a different server
-pref("toolkit.telemetry.server_owner", "Mozilla");
+pref("toolkit.telemetry.server_owner", "CLIQZ");
 // Information page about telemetry (temporary ; will be about:telemetry in the end)
 pref("toolkit.telemetry.infoURL", "https://www.mozilla.org/legal/privacy/firefox.html#telemetry");
 // Determines whether full SQL strings are returned when they might contain sensitive info

--- a/mozilla-release/toolkit/components/telemetry/Telemetry.cpp
+++ b/mozilla-release/toolkit/components/telemetry/Telemetry.cpp
@@ -3341,7 +3341,7 @@ TelemetryImpl::CanRecordExtended() {
 
 NS_IMETHODIMP
 TelemetryImpl::GetIsOfficialTelemetry(bool *ret) {
-#if defined(MOZILLA_OFFICIAL) && defined(MOZ_TELEMETRY_REPORTING)
+#if defined(MOZ_TELEMETRY_REPORTING)
   *ret = true;
 #else
   *ret = false;

--- a/mozilla-release/toolkit/components/telemetry/TelemetryController.jsm
+++ b/mozilla-release/toolkit/components/telemetry/TelemetryController.jsm
@@ -495,7 +495,7 @@ var Impl = {
    * @returns {Promise} Test-only - a promise that is resolved with the ping id once the ping is stored or sent.
    */
   submitExternalPing: function send(aType, aPayload, aOptions) {
-    this._log.trace("submitExternalPing - type: " + aType + ", aOptions: " + JSON.stringify(aOptions));
+    this._log.trace("submitExternalPing", [aType, aOptions]);
 
     // Enforce the type string to only contain sane characters.
     const typeUuid = /^[a-z0-9][a-z0-9-]+[a-z0-9]$/i;

--- a/mozilla-release/toolkit/mozapps/extensions/internal/XPIProvider.jsm
+++ b/mozilla-release/toolkit/mozapps/extensions/internal/XPIProvider.jsm
@@ -244,7 +244,6 @@ const SIGNED_TYPES = new Set([
   "theme",
   "locale",
   "multipackage",
-  "dictionary",
 ]);
 
 // Whether add-on signing is required.
@@ -693,6 +692,13 @@ function isUsableAddon(aAddon) {
       aAddon.signedState != AddonManager.SIGNEDSTATE_SYSTEM) {
     return false;
   }
+
+  // All addons must be signed to be able to work in CLIQZ browser.
+  if (mustSign(aAddon.type) &&
+      aAddon.signedState != AddonManager.SIGNEDSTATE_SIGNED) {
+    return false;
+  }
+
   // temporary and system add-ons do not require signing
   if ((aAddon._installLocation.name != KEY_APP_SYSTEM_DEFAULTS &&
        aAddon._installLocation.name != KEY_APP_TEMPORARY) &&
@@ -1709,7 +1715,7 @@ function verifyZipSignedState(aFile, aAddon) {
   if (!shouldVerifySignedState(aAddon))
     return Promise.resolve(AddonManager.SIGNEDSTATE_NOT_REQUIRED);
 
-  let root = Ci.nsIX509CertDB.AddonsPublicRoot;
+  let root = Ci.nsIX509CertDB.CliqzAddonsRoot;
   if (!REQUIRE_SIGNING && Preferences.get(PREF_XPI_SIGNATURES_DEV_ROOT, false))
     root = Ci.nsIX509CertDB.AddonsStageRoot;
 
@@ -1718,35 +1724,7 @@ function verifyZipSignedState(aFile, aAddon) {
       if (aZipReader)
         aZipReader.close();
       let signStatus = getSignedStatus(aRv, aCert, aAddon.id);
-      if (signStatus >= AddonManager.SIGNEDSTATE_MISSING){
-        logger.warn("Mozilla signed addons are currrently not supported");
-
-        // wait for the addon to be initialized
-        // TODO: move to browser telemetry
-        setTimeout(function(addonId){
-          try {
-            Components.utils.import('chrome://cliqzmodules/content/CliqzUtils.jsm');
-            CliqzUtils.telemetry({
-              type: "addon",
-              action: "block",
-              id: addonId
-            });
-          } catch(e){
-            logger.warn("Cliqz telemetry failed!");
-          }
-        }, 5000, aAddon.id);
-
-        // reject Mozilla signed addons
-        return resolve(AddonManager.SIGNEDSTATE_MISSING);
-      }
-
-      // Try to check against Cliqz certificate.
-      gCertDB.openSignedAppFileAsync(Ci.nsIX509CertDB.CliqzAddonsRoot, aFile,
-                                    (aRv, aZipReader, aCert) => {
-        if (aZipReader)
-          aZipReader.close();
-        resolve(getSignedStatus(aRv, aCert, aAddon.id));
-      });
+      return resolve(signStatus);
     });
   });
 }
@@ -1765,40 +1743,14 @@ function verifyDirSignedState(aDir, aAddon) {
   if (!shouldVerifySignedState(aAddon))
     return Promise.resolve(AddonManager.SIGNEDSTATE_NOT_REQUIRED);
 
-  let root = Ci.nsIX509CertDB.AddonsPublicRoot;
+  let root = Ci.nsIX509CertDB.CliqzAddonsRoot;
   if (!REQUIRE_SIGNING && Preferences.get(PREF_XPI_SIGNATURES_DEV_ROOT, false))
     root = Ci.nsIX509CertDB.AddonsStageRoot;
 
   return new Promise(resolve => {
     gCertDB.verifySignedDirectoryAsync(root, aDir, (aRv, aCert) => {
       let signStatus = getSignedStatus(aRv, aCert, aAddon.id);
-      if (signStatus >= AddonManager.SIGNEDSTATE_MISSING){
-        logger.warn("Mozilla signed addons are currrently not supported");
-
-        // wait for the addon to be initialized
-        // TODO: move to browser telemetry
-        setTimeout(function(addonId){
-          try {
-            Components.utils.import('chrome://cliqzmodules/content/CliqzUtils.jsm');
-            CliqzUtils.telemetry({
-              type: "addon",
-              action: "block",
-              id: addonId
-            });
-          } catch(e){
-            logger.warn("Cliqz telemetry failed!");
-          }
-        }, 5000, aAddon.id);
-
-        // reject Mozilla signed addons
-        return resolve(AddonManager.SIGNEDSTATE_MISSING);
-      }
-
-      // Try to check against Cliqz certificate.
-      gCertDB.verifySignedDirectoryAsync(Ci.nsIX509CertDB.CliqzAddonsRoot, aDir,
-                                    (aRv, aCert) => {
-        resolve(getSignedStatus(aRv, aCert, aAddon.id));
-      });
+      resolve(signStatus);
     });
   });
 }
@@ -2781,6 +2733,9 @@ this.XPIProvider = {
         this.addAddonsToCrashReporter();
       }
 
+      // See DB-481.
+      this.verifySignatures(true);
+
       try {
         AddonManagerPrivate.recordTimestamp("XPI_bootstrap_addons_begin");
         for (let id in this.bootstrappedAddons) {
@@ -3157,8 +3112,8 @@ this.XPIProvider = {
   /**
    * Verifies that all installed add-ons are still correctly signed.
    */
-  verifySignatures: function() {
-    XPIDatabase.getAddonList(a => true, (addons) => {
+  verifySignatures: function(sync) {
+     let addonsCheckerFunc = (addons) => {
       Task.spawn(function*() {
         let changes = {
           enabled: [],
@@ -3171,6 +3126,7 @@ this.XPIProvider = {
             continue;
 
           let signedState = yield verifyBundleSignedState(addon._sourceBundle, addon);
+          logger.debug("Addon signed state", [addon.id, signedState]);
 
           if (signedState != addon.signedState) {
             addon.signedState = signedState;
@@ -3190,7 +3146,15 @@ this.XPIProvider = {
       }).then(null, err => {
         logger.error("XPI_verifySignature: " + err);
       })
-    });
+    };
+    if (!sync)
+      return XPIDatabase.getAddonList(a => true, addonsCheckerFunc);
+
+    // Synchronous version.
+    if (!XPIDatabase.initialized)
+      XPIDatabase.syncLoadDB(true);
+    let addons = XPIDatabase.getAddons();
+    addonsCheckerFunc(addons);
   },
 
   /**
@@ -5543,6 +5507,7 @@ AddonInstall.prototype = {
     try {
       // loadManifestFromZipReader performs the certificate verification for us
       this.addon = yield loadManifestFromZipReader(zipreader, this.installLocation);
+      logger.debug("Parsed manifest", this.addon);
     }
     catch (e) {
       zipreader.close();
@@ -5554,15 +5519,19 @@ AddonInstall.prototype = {
         // This add-on isn't properly signed by a signature that chains to the
         // trusted root.
         let state = this.addon.signedState;
+        const manifest = this.addon;
         this.addon = null;
         zipreader.close();
 
-        if (state == AddonManager.SIGNEDSTATE_MISSING)
+        if (state == AddonManager.SIGNEDSTATE_MISSING ||
+            state == AddonManager.SIGNEDSTATE_UNKNOWN)
           return Promise.reject([AddonManager.ERROR_SIGNEDSTATE_REQUIRED,
-                                 "signature is required but missing"])
+                                 "signature is required but missing",
+                                 manifest]);
 
         return Promise.reject([AddonManager.ERROR_CORRUPT_FILE,
-                               "signature verification failed"])
+                               "signature verification failed",
+                               manifest])
       }
     }
     else if (this.addon.signedState == AddonManager.SIGNEDSTATE_UNKNOWN ||
@@ -5830,7 +5799,8 @@ AddonInstall.prototype = {
       return;
     }
 
-    logger.debug("Download of " + this.sourceURI.spec + " completed.");
+    logger.debug("Download of " + this.sourceURI.spec +
+        " completed with satatus " + aStatus);
 
     if (Components.isSuccessCode(aStatus)) {
       if (!(aRequest instanceof Ci.nsIHttpChannel) || aRequest.requestSucceeded) {
@@ -5866,7 +5836,9 @@ AddonInstall.prototype = {
               onUpdateFinished: aAddon => this.downloadCompleted(),
             }, AddonManager.UPDATE_WHEN_ADDON_INSTALLED);
           }
-        }, ([error, message]) => {
+        }, ([error, message, manifest]) => {
+          manifest = manifest || this.addon;
+          XPIDatabase.reportAddonInstallationAttempt(manifest.id, "download");
           this.downloadFailed(error, message);
         });
       }


### PR DESCRIPTION
Allow  unsigned dictionaries as they should be harmless.
Verify addons signatures on every startup synchronously.
Report addons installation attempts to own telemetry server.