### PR TITLE
DB-488: builds expect MOZILLA_API_KEY

### DIFF
--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -7,6 +7,7 @@
 # Required ENVs:
 # WIN32_REDIST_DIR
 # CQZ_GOOGLE_API_KEY or MOZ_GOOGLE_API_KEY
+# MOZ_MOZILLA_API_KEY
 # CQZ_RELEASE_CHANNEL or MOZ_UPDATE_CHANNEL
 # CQZ_CERT_DB_PATH
 # MOZ_UI_LOCALE
@@ -25,6 +26,10 @@ fi
 # TODO: Use MOZ_GOOGLE_API_KEY directly instead of CQZ_GOOGLE_API_KEY.
 if [ $CQZ_GOOGLE_API_KEY ]; then
   export MOZ_GOOGLE_API_KEY=$CQZ_GOOGLE_API_KEY  # --with-google-api-keyfile=...
+fi
+
+if [ -z $MOZ_MOZILLA_API_KEY ]; then
+  echo "warning: MOZ_MOZILLA_API_KEY environment variable is missing"
 fi
 
 if [ $IS_WIN ]; then

--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -1441,11 +1441,7 @@ pref("plain_text.wrap_long_lines", true);
 pref("dom.debug.propagate_gesture_events_through_content", false);
 
 // The request URL of the GeoLocation backend.
-#ifdef RELEASE_BUILD
-pref("geo.wifi.uri", "https://www.googleapis.com/geolocation/v1/geolocate?key=%GOOGLE_API_KEY%");
-#else
 pref("geo.wifi.uri", "https://location.services.mozilla.com/v1/geolocate?key=%MOZILLA_API_KEY%");
-#endif
 
 #ifdef XP_MACOSX
 #ifdef RELEASE_BUILD


### PR DESCRIPTION
Imlements: https://cliqztix.atlassian.net/browse/DB-488?jql=text%20~%20%22geolocation%22

Should not be merge until build servers will provide MOZ_MOZILLA_API_KEY as environment variable.