### PR TITLE
DB-379: delete distribution.js file on uninstall only.

### DIFF
--- a/mozilla-release/browser/installer/windows/nsis/installer.nsi
+++ b/mozilla-release/browser/installer/windows/nsis/installer.nsi
@@ -260,6 +260,7 @@ Section "-InstallStartCleanup"
   ${If} ${FileExists} "$INSTDIR\defaults\pref\channel-prefs.js"
     Delete "$INSTDIR\defaults\pref\channel-prefs.js"
   ${EndIf}
+  ; CLIQZ Browser: we don't replace already existing distribution.js file in pref
   ${If} ${FileExists} "$INSTDIR\defaults\pref"
     RmDir "$INSTDIR\defaults\pref"
   ${EndIf}

--- a/mozilla-release/browser/installer/windows/nsis/uninstaller.nsi
+++ b/mozilla-release/browser/installer/windows/nsis/uninstaller.nsi
@@ -402,6 +402,10 @@ Section "Uninstall"
   ${If} ${FileExists} "$INSTDIR\defaults\pref\channel-prefs.js"
     Delete /REBOOTOK "$INSTDIR\defaults\pref\channel-prefs.js"
   ${EndIf}
+  ; CLIQZ Browser: remove distribution.js file on uninstall stage
+  ${If} ${FileExists} "$INSTDIR\defaults\pref\distribution.js"
+    Delete /REBOOTOK "$INSTDIR\defaults\pref\distribution.js"
+  ${EndIf}
   ${If} ${FileExists} "$INSTDIR\defaults\pref"
     RmDir /REBOOTOK "$INSTDIR\defaults\pref"
   ${EndIf}


### PR DESCRIPTION
Do not delete this file while installing over already existing version