### PR TITLE
DB-549: Create DE build as Localization Repack

### DIFF
--- a/cliqz_env.sh
+++ b/cliqz_env.sh
@@ -71,7 +71,12 @@ export MOZ_AUTOMATION_UPLOAD=1
 export CQZ_BALROG_DOMAIN=balrog-admin.10e99.net
 export BALROG_PATH=../build-tools/scripts/updates
 export S3_BUCKET=repository.cliqz.com
-export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/${LANG:0:2}`
+# this condition only for transaction period between old and new build system
+if [ -z $CQZ_BUILD_ID ]; then
+  export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/${LANG:0:2}`
+else
+  export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID`
+fi
 
 OBJ_DIR=$MOZ_OBJDIR
 if [ $IS_MAC_OS ]; then

--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -10,7 +10,9 @@
 # MOZ_MOZILLA_API_KEY
 # CQZ_RELEASE_CHANNEL or MOZ_UPDATE_CHANNEL
 # CQZ_CERT_DB_PATH
-# MOZ_UI_LOCALE
+#
+# Optional ENVs:
+#  CQZ_BUILD_LOCALIZATION - for build DE localization
 
 set -e
 set -x
@@ -40,17 +42,17 @@ if [ -z "$LANG" ]; then
   LANG='en-US'
 fi
 
-#  for german builds
-# TODO: Use MOZ_UI_LOCALE directly.
+# for support old build
 if [[ "$LANG" == 'de' ]]; then
-echo '***** German builds detected *****'
-  IS_DE=true
-  if [[ $IS_MAC_OS ]]; then
-    export L10NBASEDIR=../../l10n  # --with-l10n-base=...
-  else
-    export L10NBASEDIR=../l10n  # --with-l10n-base=...
-  fi
-  export MOZ_UI_LOCALE=de  # --enable-ui-locale=...
+  echo '***** German builds detected *****'
+  export MOZ_UI_LOCALE=de
+fi
+
+# for localization repack
+if [[ $IS_MAC_OS ]]; then
+  export L10NBASEDIR=../../l10n  # --with-l10n-base=...
+else
+  export L10NBASEDIR=../l10n  # --with-l10n-base=...
 fi
 
 echo '***** Building *****'
@@ -71,6 +73,14 @@ if [[ $IS_MAC_OS ]]; then
   export MOZ_OBJDIR=$MOZ_OBJDIR_BACKUP
 else
   ./mach package
+fi
+
+echo '***** Build DE language pack *****'
+if [ $CQZ_BUILD_LOCALIZATION ]; then
+  cd $OLDPWD
+  cd $SRC_BASE/$MOZ_OBJDIR/browser/locales
+  $MAKE merge-de LOCALE_MERGEDIR=$(PWD)/mergedir
+  $MAKE installers-de LOCALE_MERGEDIR=$(PWD)/mergedir
 fi
 
 echo '***** Build & package finished successfully. *****'

--- a/magic_upload_files.sh
+++ b/magic_upload_files.sh
@@ -9,6 +9,10 @@ source cliqz_env.sh
 cd $SRC_BASE
 cd $OBJ_DIR
 
+echo '***** Generate MAR for DE, if needed *****'
+if [ $CQZ_BUILD_LOCALIZATION ]; then
+  $MAKE -C ./tools/update-packaging full-update AB_CD=de
+fi
 echo '***** Packaging MAR *****'
 $MAKE update-packaging
 
@@ -18,16 +22,19 @@ if [ $CQZ_CERT_DB_PATH ]; then
     MAR_CERT_NAME="Cliqz GmbH's DigiCert Inc ID"
   fi
   echo '***** Signing mar *****'
-  MAR_FILE=`ls dist/update/*.mar | head -n 1`
-  # signmar is somehow dependent on its execution path. It refuses to work when
-  # launched using relative paths, and gives unrelated error:
-  # "Could not initialize NSS". BEWARE!
-  SIGNMAR_ABS_DIR=$(cd dist/bin/; pwd)
-  $SIGNMAR_ABS_DIR/signmar -d $CQZ_CERT_DB_PATH -n "$MAR_CERT_NAME" \
-    -s $MAR_FILE $MAR_FILE.signed
+  MAR_FILES=dist/update/*.mar
+  for MAR_FILE in $MAR_FILES
+  do
+    # signmar is somehow dependent on its execution path. It refuses to work when
+    # launched using relative paths, and gives unrelated error:
+    # "Could not initialize NSS". BEWARE!
+    SIGNMAR_ABS_DIR=$(cd dist/bin/; pwd)
+    $SIGNMAR_ABS_DIR/signmar -d $CQZ_CERT_DB_PATH -n "$MAR_CERT_NAME" \
+      -s $MAR_FILE $MAR_FILE.signed
 
-  mv $MAR_FILE $MAR_FILE.unsigned
-  cp $MAR_FILE.signed $MAR_FILE
+    mv $MAR_FILE $MAR_FILE.unsigned
+    cp $MAR_FILE.signed $MAR_FILE
+  done
 fi
 
 echo '***** Uploading MAR and package files *****'
@@ -41,5 +48,25 @@ python $ROOT_PATH/build-tools/scripts/updates/balrog-submitter.py \
   --credentials-file $ROOT_PATH/$SRC_BASE/build/creds.txt --username balrogadmin \
   --api-root http://$CQZ_BALROG_DOMAIN/api \
   --build-properties build_properties.json
+
+if [ $CQZ_BUILD_LOCALIZATION ]; then
+  # We need to copy this files because we build DE version as repack step, so
+  # they don't exist for DE build (but must be before uploading stage, so they)
+  # fall into mach_build_properties.json file
+  for f in dist/CLIQZ-*.{txt,json}; do
+    cp $f `echo $f | sed "s/en-US/de/"`
+  done
+
+  $MAKE upload AB_CD=de
+
+  echo '***** Genereting build_properties.json *****'
+  $ROOT_PATH/$SRC_BASE/build/gen_build_properties.py
+
+  echo '***** Submiting to Balrog *****'
+  python $ROOT_PATH/build-tools/scripts/updates/balrog-submitter.py \
+    --credentials-file $ROOT_PATH/$SRC_BASE/build/creds.txt --username balrogadmin \
+    --api-root http://$CQZ_BALROG_DOMAIN/api \
+    --build-properties build_properties.json
+fi
 
 cd $ROOT_PATH

--- a/mozilla-release/config/rules.mk
+++ b/mozilla-release/config/rules.mk
@@ -1201,11 +1201,22 @@ endif # SDK_BINARY
 # CHROME PACKAGING
 
 # Cliqz additional distribution files
+# For transition period (moving to new build system) let's use both, old and new
+# variant for downloading XPI.
+# NEW:
+ifdef CQZ_BUILD_ID
+CLIQZ_EXT_URL = "http://repository.cliqz.com/dist/$(MOZ_UPDATE_CHANNEL)/$(CQZ_VERSION)/$(CQZ_BUILD_ID)/cliqz@cliqz.com.xpi"
+endif  # CQZ_BUILD_ID
+
+# OLD:
+ifndef CQZ_BUILD_ID
 # TODO: Move to external file.
 CLIQZ_EXT_URL = "http://cdn2.cliqz.com/update/browser_beta/latest.xpi"
 ifeq (release, $(CQZ_RELEASE_CHANNEL))
 CLIQZ_EXT_URL = "http://cdn2.cliqz.com/update/browser/Cliqz.1.4.0.xpi"
 endif  # ifeq (release, $(CQZ_RELEASE_CHANNEL))
+endif  # CQZ_BUILD_ID
+
 DIST_RESPATH = $(DIST)/bin
 EXTENSIONS_PATH = $(DIST_RESPATH)/browser/features
 $(EXTENSIONS_PATH):

--- a/mozilla-release/tools/update-packaging/Makefile.in
+++ b/mozilla-release/tools/update-packaging/Makefile.in
@@ -36,8 +36,15 @@ full-update:: complete-patch
 ifeq ($(OS_TARGET), WINNT)
 MOZ_PKG_FORMAT	:= SFX7Z
 UNPACKAGE	= '$(subst $(DIST),$(ABS_DIST),$(INSTALLER_PACKAGE))'
+# CLIQZ. This doesn't work as expected on build machine, when trying to generate
+# update package (mar) with localization installer (AB_CD). Script searching for
+# installer in different location, where it doesn't exist (and can not exist in
+# current build system). Looks like Mozilla create update repacks on separate
+# build machine, not which one build a browser installer itself
+ifdef 0
 ifdef AB_CD
 UNPACKAGE	= '$(PACKAGE_BASE_DIR)/$(PACKAGE)'
+endif
 endif
 endif
 

--- a/sign_win.bat
+++ b/sign_win.bat
@@ -13,11 +13,12 @@ echo %lang%
 set timestamp_server_sha1=http://timestamp.verisign.com/scripts/timstamp.dll
 set timestamp_server_sha256=http://timestamp.geotrust.com/tsa
 
-%archivator_exe% x -opkg -y dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
+if exist ./pkg_%lang% rmdir /q /s "pkg_%lang%"
+%archivator_exe% x -opkg_%lang% -y dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 
 echo %CLZ_SIGNTOOL_PATH%
 
-cd pkg
+cd pkg_%lang%
 for /R %%f in (
   *.exe *.dll
 ) do (
@@ -35,7 +36,7 @@ for /R %%f in (
 del installer.7z
 %archivator_exe% a -r -t7z installer.7z -mx -m0=BCJ2 -m1=LZMA:d25 -m2=LZMA:d19 -m3=LZMA:d1 -mb0:1 -mb0s1:2 -mb0s2:3
 cd ..
-copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\instgen\app.tag + pkg\installer.7z dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
+copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\instgen\app.tag + pkg_%lang%\installer.7z dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 
 "%CLZ_SIGNTOOL_PATH%" sign /t %timestamp_server_sha1% /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
 "%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server_sha256% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% /as dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe


### PR DESCRIPTION
To be able to build DE build please set up CQZ_BUILD_LOCALIZATION env variable (any value)
Language repack could be done in 3 steps (on Windows):
1. Build an installer first (based on en-US installer)
2. Sign the installer (similar as en-US)
3. Create .complete.mar update package

I tried to support old a new build process. To use new way to publish and use artifacts - please use CQZ_BUILD_ID