### PR TITLE
DB-37: fix Linux build

### DIFF
--- a/mozilla-release/browser/config/cliqz-release.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release.mozconfig
@@ -5,15 +5,16 @@
 ac_add_options --disable-debug
 ac_add_options --disable-tests
 ac_add_options --enable-release
-ac_add_options --enable-warnings-as-errors
 
 if echo $OSTYPE | grep -q "darwin"; then
   # Enable universal MacOS executable build
   . $topsrcdir/build/macosx/universal/mozconfig
+  ac_add_options --enable-warnings-as-errors
 fi
 
 if echo $OSTYPE | grep -q "msys"; then
   # Windows specific flags
+  ac_add_options --enable-warnings-as-errors
   ac_add_options --enable-jemalloc
   ac_add_options --enable-require-all-d3dc-versions
   ac_add_options --enable-eme=adobe

--- a/mozilla-release/toolkit/mozapps/installer/linux/rpm/mozilla.spec
+++ b/mozilla-release/toolkit/mozapps/installer/linux/rpm/mozilla.spec
@@ -41,7 +41,7 @@ requires:   %{name} = %{version}-%{release}
 %{pr_name} SDK libraries, headers and interface descriptions
 %endif
 
-%if %{?createtests:1}
+%if 0%{?createtests:1}
 %package tests
 Summary:    %{pr_name} tests
 Group:      Developement/Libraries
@@ -81,7 +81,7 @@ for i in $(cat icons.list) ; do
 done
 rm icons.list #cleanup
 
-%if %{?createtests:1}
+%if 0%{?createtests:1}
 #wastefully creates a zip file, but ensures that we stage all test suites
 make package-tests
 testdir=$RPM_BUILD_ROOT/%{_datadir}/%{_testsinstalldir}/tests
@@ -129,7 +129,7 @@ fi
 %endif
 
 
-%if %{?createtests:1}
+%if 0%{?createtests:1}
 %files tests
 %{_datadir}/%{_testsinstalldir}/tests/
 %endif


### PR DESCRIPTION
* remove --enable-warnings-as-errors from Linux build
* fix --disable-tests flag processing (http://backreference.org/2011/09/17/some-tips-on-rpm-conditional-macros/) - this patch could be send to Mozilla