### PR TITLE
DB-642: Fix apple bundle PkgInfo

### DIFF
--- a/mozilla-release/browser/app/Makefile.in
+++ b/mozilla-release/browser/app/Makefile.in
@@ -104,5 +104,8 @@ tools repackage:: $(DIST)/bin/$(MOZ_APP_NAME)
 	rsync -aL $(DIST)/bin/$(MOZ_APP_NAME) $(dist_dest)/Contents/MacOS
 	cp -RL $(DIST)/branding/firefox.icns $(dist_dest)/Contents/Resources/firefox.icns
 	cp -RL $(DIST)/branding/document.icns $(dist_dest)/Contents/Resources/document.icns
-	printf APPLMOZB > $(dist_dest)/Contents/PkgInfo
+	{ echo 'APPL' ; \
+	  defaults read `pwd`/$(dist_dest)/Contents/Info.plist CFBundleSignature \
+	  ; } | sed -e 'N;s/\n//' > $(dist_dest)/Contents/PkgInfo
+
 endif


### PR DESCRIPTION
Use CFBundleSignature value to write into PkgInfo