### PR TITLE
[WIP] Build: unpack https-everwhere

### DIFF
--- a/mozilla-release/config/rules.mk
+++ b/mozilla-release/config/rules.mk
@@ -1235,6 +1235,8 @@ $(HTTPSE_XPI_PATH): $(EXTENSIONS_PATH)
 ifdef HTTPSE_EXT_URL
 	echo HTTPSE_XPI_PATH in `pwd`
 	wget --output-document $(HTTPSE_XPI_PATH) $(HTTPSE_EXT_URL)
+	unzip $(HTTPSE_XPI_PATH) -d $(EXTENSIONS_PATH)/https-everywhere@cliqz.com
+	rm $(HTTPSE_XPI_PATH)
 endif
 
 DISTR_INI = $(DIST_RESPATH)/distribution/distribution.ini

--- a/mozilla-release/config/rules.mk
+++ b/mozilla-release/config/rules.mk
@@ -1236,6 +1236,8 @@ ifdef HTTPSE_EXT_URL
 	echo HTTPSE_XPI_PATH in `pwd`
 	wget --output-document $(HTTPSE_XPI_PATH) $(HTTPSE_EXT_URL)
 	unzip $(HTTPSE_XPI_PATH) -d $(EXTENSIONS_PATH)/https-everywhere@cliqz.com
+	unzip $(EXTENSIONS_PATH)/https-everywhere@cliqz.com/chrome.jar -d $(EXTENSIONS_PATH)/https-everywhere@cliqz.com/chrome
+	rm $(EXTENSIONS_PATH)/https-everywhere@cliqz.com/chrome.jar
 	rm $(HTTPSE_XPI_PATH)
 endif
 

--- a/mozilla-release/config/rules.mk
+++ b/mozilla-release/config/rules.mk
@@ -1236,8 +1236,7 @@ ifdef HTTPSE_EXT_URL
 	echo HTTPSE_XPI_PATH in `pwd`
 	wget --output-document $(HTTPSE_XPI_PATH) $(HTTPSE_EXT_URL)
 	unzip $(HTTPSE_XPI_PATH) -d $(EXTENSIONS_PATH)/https-everywhere@cliqz.com
-	unzip $(EXTENSIONS_PATH)/https-everywhere@cliqz.com/chrome.jar -d $(EXTENSIONS_PATH)/https-everywhere@cliqz.com/chrome
-	rm $(EXTENSIONS_PATH)/https-everywhere@cliqz.com/chrome.jar
+	chmod a+r -R $(EXTENSIONS_PATH)/https-everywhere@cliqz.com
 	rm $(HTTPSE_XPI_PATH)
 endif
 


### PR DESCRIPTION
https-everywhere is unpack extension due to fact it access nss libraries. we need to respect that if we want it to work