### PR TITLE
DB-666: some improvement for new build system

### DIFF
--- a/cliqz_env.sh
+++ b/cliqz_env.sh
@@ -73,7 +73,11 @@ export S3_BUCKET=repository.cliqz.com
 if [ -z $CQZ_BUILD_ID ]; then
   export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/${LANG:0:2}`
 else
-  export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID`
+  # set path on S3 with BUILD_ID. From this path we take *.xpi and upload
+  # build artifacts back (to locale folder, same as FF)
+  export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID/en-US`
+  # set our own BUILD_ID in new build system, must be specified in format %Y%m%d%H%M%S
+  export MOZ_BUILD_DATE=$CQZ_BUILD_ID
 fi
 
 OBJ_DIR=$MOZ_OBJDIR

--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -12,7 +12,7 @@
 # CQZ_CERT_DB_PATH
 #
 # Optional ENVs:
-#  CQZ_BUILD_LOCALIZATION - for build DE localization
+#  CQZ_BUILD_DE_LOCALIZATION - for build DE localization
 
 set -e
 set -x
@@ -72,7 +72,7 @@ else
 fi
 
 echo '***** Build DE language pack *****'
-if [ $CQZ_BUILD_LOCALIZATION ]; then
+if [ $CQZ_BUILD_DE_LOCALIZATION ]; then
   cd $OLDPWD
   cd $SRC_BASE/$MOZ_OBJDIR/browser/locales
   $MAKE merge-de LOCALE_MERGEDIR=$(PWD)/mergedir

--- a/magic_upload_files.sh
+++ b/magic_upload_files.sh
@@ -10,7 +10,7 @@ cd $SRC_BASE
 cd $OBJ_DIR
 
 echo '***** Generate MAR for DE, if needed *****'
-if [ $CQZ_BUILD_LOCALIZATION ]; then
+if [ $CQZ_BUILD_DE_LOCALIZATION ]; then
   $MAKE -C ./tools/update-packaging full-update AB_CD=de
 fi
 echo '***** Packaging MAR *****'
@@ -49,7 +49,7 @@ python $ROOT_PATH/build-tools/scripts/updates/balrog-submitter.py \
   --api-root http://$CQZ_BALROG_DOMAIN/api \
   --build-properties build_properties.json
 
-if [ $CQZ_BUILD_LOCALIZATION ]; then
+if [ $CQZ_BUILD_DE_LOCALIZATION ]; then
   # We need to copy this files because we build DE version as repack step, so
   # they don't exist for DE build (but must be before uploading stage, so they)
   # fall into mach_build_properties.json file
@@ -57,6 +57,7 @@ if [ $CQZ_BUILD_LOCALIZATION ]; then
     cp $f `echo $f | sed "s/en-US/de/"`
   done
 
+  export S3_UPLOAD_PATH=`echo $S3_UPLOAD_PATH | sed s/en-US/de/`
   $MAKE upload AB_CD=de
 
   echo '***** Genereting build_properties.json *****'

--- a/mozilla-release/toolkit/mozapps/installer/package-name.mk
+++ b/mozilla-release/toolkit/mozapps/installer/package-name.mk
@@ -152,7 +152,7 @@ ifndef INCLUDED_RCS_MK
   include $(MOZILLA_DIR)/config/makefiles/makeutils.mk
 endif
 
-MOZ_SOURCE_STAMP = $(firstword $(shell git rev-parse HEAD))
+MOZ_SOURCE_STAMP = $(firstword $(shell git rev-parse HEAD 2>/dev/null))
 
 ###########################################################################
 # bug: 746277 - preserve existing functionality.

--- a/sign_win.bat
+++ b/sign_win.bat
@@ -15,6 +15,7 @@ set timestamp_server_sha256=http://timestamp.geotrust.com/tsa
 
 if exist ./pkg_%lang% rmdir /q /s "pkg_%lang%"
 %archivator_exe% x -opkg_%lang% -y dist\install\sea\CLIQZ-%ff_exe%.win32.installer.exe
+if not exist ./pkg_%lang% (goto :error)
 
 echo %CLZ_SIGNTOOL_PATH%
 


### PR DESCRIPTION
CQZ_BUILD_ID. It is hard to totally replace FF "buildid" because it spread all over the build scripts and expected exactly in format "%Y%m%d%H%M%S". We need to use same format in our build. Jenkins must generate environment variable CQZ_BUILD_ID (or can be set up manually on dev environment)

CQZ_BUILD_DE_LOCALIZATION. Optional, must be set up if we need in DE build (build with language repack)