### PR TITLE
DB-902: fix update channel information

### DIFF
--- a/mozilla-release/browser/config/cliqz-release.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release.mozconfig
@@ -2,6 +2,7 @@
 
 . $topsrcdir/browser/config/cliqz.mozconfig
 
+ac_add_options --enable-update-channel=${MOZ_UPDATE_CHANNEL}
 ac_add_options --enable-release
 
 if echo $OSTYPE | grep -q "darwin"; then


### PR DESCRIPTION
Due to changes in mozilla-release\build\moz.configure\init.configure parameter --enable-update-channel must be specified