### PR TITLE
DB-919: Duplicated Tab is not in Forget Mode

### DIFF
--- a/mozilla-release/browser/base/content/tabbrowser.xml
+++ b/mozilla-release/browser/base/content/tabbrowser.xml
@@ -2045,6 +2045,15 @@
             var evt = new CustomEvent("TabOpen", { bubbles: true, detail });
             t.dispatchEvent(evt);
 
+            // CLIQZ (DB-919): We use "private" attribute in the duplicateTab()
+            // function on SessionStore.jsm (line 2086)
+            // This block is moved outside the IF condition below so that it will
+            // be excuted even though the IF condition is not triggered.
+            // Go private before navigating if requested.
+            if (aPrivate) {
+              t.private = true;
+            }
+
             // If we didn't swap docShells with a preloaded browser
             // then let's just continue loading the page normally.
             if (!usingPreloadedContent && !uriIsAboutBlank) {
@@ -2063,11 +2072,6 @@
               if (aAllowMixedContent)
                 flags |= Ci.nsIWebNavigation.LOAD_FLAGS_ALLOW_MIXED_CONTENT;
               try {
-                // Go private before navigating if requested.
-                if (aPrivate) {
-                  t.private = true;
-                }
-
                 b.loadURIWithFlags(aURI, {
                                    flags: flags,
                                    referrerURI: aNoReferrer ? null: aReferrerURI,

--- a/mozilla-release/browser/components/sessionstore/SessionStore.jsm
+++ b/mozilla-release/browser/components/sessionstore/SessionStore.jsm
@@ -1039,7 +1039,7 @@ var SessionStoreInternal = {
           this._globalState.setFromState(aInitialState);
 
           let overwrite = this._isCmdLineEmpty(aWindow, aInitialState) &&
-              gSessionStartup.willOverrideHomepage;
+            !this._prefBranch.getBoolPref("startup.addFreshTab");
           let options = {firstWindow: true, overwriteTabs: overwrite};
           this.restoreWindows(aWindow, aInitialState, options);
         }
@@ -2092,10 +2092,14 @@ var SessionStoreInternal = {
     }
 
     // Create a new tab.
+    // CLIQZ (DB-919): Added aTab.private param into addTab so that new tab will be private
+    // if it's duplicated from a private tab
     let userContextId = aTab.getAttribute("usercontextid");
     let newTab = aTab == aWindow.gBrowser.selectedTab ?
-      aWindow.gBrowser.addTab(null, {relatedToCurrent: true, ownerTab: aTab, userContextId}) :
-      aWindow.gBrowser.addTab(null, {userContextId});
+      aWindow.gBrowser.addTab(null,
+        {relatedToCurrent: true, ownerTab: aTab, userContextId, private: aTab.private}) :
+      aWindow.gBrowser.addTab(null,
+        {userContextId, private: aTab.private});
 
     // Set tab title to "Connecting..." and start the throbber to pretend we're
     // doing something while actually waiting for data from the frame script.


### PR DESCRIPTION
Use "private" attribute of contextTab for duplicated Tab