### PR TITLE
DB-970: update extension to 1.10.0

### DIFF
--- a/mozilla-release/config/rules.mk
+++ b/mozilla-release/config/rules.mk
@@ -1155,7 +1155,7 @@ ifndef CQZ_BUILD_ID
 CLIQZ_EXT_URL = "http://cdn2.cliqz.com/update/browser_beta/latest.xpi"
 HTTPSE_EXT_URL = "https://s3.amazonaws.com/cdncliqz/update/browser_beta/https-everywhere/https-everywhere@cliqz.com-5.2.4-browser_beta-signed.xpi"
 ifeq (release, $(CQZ_RELEASE_CHANNEL))
-CLIQZ_EXT_URL = "http://cdn2.cliqz.com/update/browser/Cliqz.1.9.2.xpi"
+CLIQZ_EXT_URL = "http://cdn2.cliqz.com/update/browser/Cliqz.1.10.0.xpi"
 HTTPSE_EXT_URL = "https://s3.amazonaws.com/cdncliqz/update/browser/https-everywhere/https-everywhere@cliqz.com-5.2.4-browser-signed.xpi"
 endif  # ifeq (release, $(CQZ_RELEASE_CHANNEL))
 endif  # CQZ_BUILD_ID


### PR DESCRIPTION
@alver-cliqz can we please have a new version 1.8.1 of the browser containing this update?