### PR TITLE
DB-731: Restore Session Tab should be opened by default in case browser was crashed

### DIFF
--- a/mozilla-release/browser/components/sessionstore/SessionStore.jsm
+++ b/mozilla-release/browser/components/sessionstore/SessionStore.jsm
@@ -1039,7 +1039,7 @@ var SessionStoreInternal = {
           this._globalState.setFromState(aInitialState);
 
           let overwrite = this._isCmdLineEmpty(aWindow, aInitialState) &&
-            !this._prefBranch.getBoolPref("startup.addFreshTab");
+            gSessionStartup.willOverrideHomepage;
           let options = {firstWindow: true, overwriteTabs: overwrite};
           this.restoreWindows(aWindow, aInitialState, options);
         }


### PR DESCRIPTION
Was broken in #409
Restoring original fix from #412 
