### PR TITLE
DB-1070: remove aushelper extension from CLIQZ browser

### DIFF
--- a/mozilla-release/browser/extensions/moz.build
+++ b/mozilla-release/browser/extensions/moz.build
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 DIRS += [
-    'aushelper',
+#    'aushelper',
 #    'e10srollout',
     'pdfjs',
 #    'pocket',


### PR DESCRIPTION
Based on https://bugzilla.mozilla.org/show_bug.cgi?id=1311515 it still not good plus we can not use it properly