### PR TITLE
DB-1067: fix error in SafeBrowsing lists processing

### DIFF
--- a/mozilla-release/toolkit/components/url-classifier/SafeBrowsing.jsm
+++ b/mozilla-release/toolkit/components/url-classifier/SafeBrowsing.jsm
@@ -181,8 +181,10 @@ this.SafeBrowsing = {
      this.malwareLists,
      this.downloadBlockLists,
      this.downloadAllowLists,
+#if 0
      this.trackingProtectionLists,
      this.trackingProtectionWhitelists,
+#endif
      this.blockedLists] = tablePreferences.map(getLists);
 
     this.updateProviderURLs();


### PR DESCRIPTION
Cliqz doesn't use urlclassifier.trackingTable and urlclassifier.trackingWhitelistTable