### PR TITLE
DB-799: Add signals for Auto Forget Mode to Browser Telemetry

### DIFF
--- a/mozilla-release/browser/components/AutoForgetTabsService.js
+++ b/mozilla-release/browser/components/AutoForgetTabsService.js
@@ -29,6 +29,18 @@ XPCOMUtils.defineLazyGetter(this, "nsJSON", () => {
 const browserStrings = Services.strings.createBundle(
     "chrome://browser/locale/browser.properties");
 
+var telemetry = {
+  states: {
+    NOTIFICATION_DISPLAYED: 0,
+    USER_PICKED_RELOAD_IN_NORMAL_MODE: 1,
+    USER_PICKED_ALWAYS_LOAD_IN_NORMAL_MODE: 2,
+    USER_PICKED_CHANGE_SETTINGS: 3
+  },
+  updateHistogram: function(state) {
+    Services.telemetry.getHistogramById("AUTO_FORGET_TAB_NOTIFICATION_STATES").add(state);
+  }
+};
+
 /**
  * This is a XPCOM-service providing access to domain database and controls for
  * "Automatic Forget Tabs" feature.
@@ -126,6 +138,7 @@ AutoForgetTabsService.prototype = {
 
   // RPC
   notifyAutoSwitched: function AFTSvc_notifyAutoSwitched(browser) {
+    telemetry.updateHistogram(telemetry.states.NOTIFICATION_DISPLAYED);
     const buttons = [
       {
         label: browserStrings.GetStringFromName("apt.notification.revertButton"),
@@ -134,6 +147,7 @@ AutoForgetTabsService.prototype = {
         popup: null,
         callback: (notification, descr) => {
           this._reloadBrowserAsNormal(browser);
+          telemetry.updateHistogram(telemetry.states.USER_PICKED_RELOAD_IN_NORMAL_MODE);
           return false;
         }
       },
@@ -145,6 +159,7 @@ AutoForgetTabsService.prototype = {
         popup: null,
         callback: (notification, descr) => {
           this._reloadBrowserAsNormal(browser, true);
+          telemetry.updateHistogram(telemetry.states.USER_PICKED_ALWAYS_LOAD_IN_NORMAL_MODE);
           return false;
         }
       },
@@ -155,6 +170,7 @@ AutoForgetTabsService.prototype = {
         popup: null,
         callback: (notification, descr) => {
           browser.ownerGlobal.openPreferences("panePrivacy");
+          telemetry.updateHistogram(telemetry.states.USER_PICKED_CHANGE_SETTINGS);
           return false;
         }
       }

--- a/mozilla-release/toolkit/components/telemetry/Histograms.json
+++ b/mozilla-release/toolkit/components/telemetry/Histograms.json
@@ -10074,5 +10074,14 @@
     "bug_numbers": [1284017],
     "description": "When restoring tabs on startup, reading from sessionstore.js failed, even though the file exists and is not containing an explicitly empty window.",
     "cpp_guard": "ANDROID"
+  },
+  "AUTO_FORGET_TAB_NOTIFICATION_STATES": {
+    "alert_emails": [],
+    "expires_in_version": "never",
+    "bug_numbers": [],
+    "kind": "enumerated",
+    "n_values": 6,
+    "description": "The states the Auto Forget Tab notification goes through. 0: The notification was displayed. 1: User picked 'Reload in Normal Mode'. 2: User picked 'Always load in Normal Mode'. 3: User picked 'Change Settings'. Other values are reserved for future uses.",
+    "releaseChannelCollection": "opt-out"
   }
 }


### PR DESCRIPTION
What we measure:

- number of times the Auto Forget Tab notification was displayed
- number of times user picked "Reload in Normal Mode"
- number of times user picked "Always load in Normal Mode"
- number of times user picked "Change Settings"

@maxim-cliqz, @luciancor: that's my first piece of code in JS, so I'd appreciate a review :)