### PR TITLE
DB-1200: fix problem with updater on About dialog.

### DIFF
--- a/mozilla-release/browser/base/content/aboutDialog.js
+++ b/mozilla-release/browser/base/content/aboutDialog.js
@@ -42,6 +42,8 @@ function init(aEvent)
     // Pref is unset
   }
 
+// CLIQZ. We don't use "version" element in CLIQZ browser at all
+/*
   // Include the build ID and display warning if this is an "a#" (nightly or aurora) build
   let versionField = document.getElementById("version");
   let version = Services.appinfo.version;
@@ -63,7 +65,7 @@ function init(aEvent)
                      : "aboutDialog.architecture.thirtyTwoBit";
   let arch = bundle.GetStringFromName(archResource);
   versionField.textContent += ` (${arch})`;
-
+*/
   if (AppConstants.MOZ_UPDATER) {
     gAppUpdater = new appUpdater();
 

--- a/mozilla-release/browser/base/content/aboutDialog.xul
+++ b/mozilla-release/browser/base/content/aboutDialog.xul
@@ -45,6 +45,7 @@
       <vbox id="leftBox" flex="1"/>
       <vbox id="rightBox" flex="1">
 #if 0
+# CLIQZ. Don't use version label on About dialog.
         <hbox align="baseline">
 #expand <label id="version">__MOZ_APP_VERSION_DISPLAY__</label>
 #ifndef NIGHTLY_BUILD


### PR DESCRIPTION
We don't use "version" element on About dialog in CLIQZ browser.