### PR TITLE
DB-1237: CQZ_GOOGLE_API_KEY and MOZ_MOZILLA_API_KEY

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -12,8 +12,6 @@ ECHO [%TIME%] BUILD.CMD STARTS =========
 ::  CQZ_WORKSPACE - path to source code
 ::  CLZ_CERTIFICATE_PATH - path to certificate for digital signing
 ::  CLZ_CERTIFICATE_PWD - password for certificate
-::  CQZ_GOOGLE_API_KEY - Google API key
-::  MOZ_MOZILLA_API_KEY - Mozilla API key
 ::
 :: Optional parameters:
 ::  CQZ_RELEASE_CHANNEL - if not set will be set to "beta"

--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -25,15 +25,6 @@ if $CLOBBER; then
   ./mach clobber
 fi
 
-# TODO: Use MOZ_GOOGLE_API_KEY directly instead of CQZ_GOOGLE_API_KEY.
-if [ $CQZ_GOOGLE_API_KEY ]; then
-  export MOZ_GOOGLE_API_KEY=$CQZ_GOOGLE_API_KEY  # --with-google-api-keyfile=...
-fi
-
-if [ -z $MOZ_MOZILLA_API_KEY ]; then
-  echo "warning: MOZ_MOZILLA_API_KEY environment variable is missing"
-fi
-
 if [ -z "$LANG" ]; then
   LANG='en-US'
 fi

--- a/mozilla-release/browser/config/cliqz-release.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release.mozconfig
@@ -17,6 +17,11 @@ if echo $OSTYPE | grep -q "msys"; then
   ac_add_options --enable-jemalloc
   ac_add_options --enable-require-all-d3dc-versions
   ac_add_options --enable-eme=+adobe
+  ac_add_options --with-mozilla-api-keyfile=c:/builds/mozilla-desktop-geoloc-api.key
+  ac_add_options --with-google-api-keyfile=c:/builds/google-desktop-api.key
+else
+  ac_add_options --with-mozilla-api-keyfile=/builds/mozilla-desktop-geoloc-api.key
+  ac_add_options --with-google-api-keyfile=/builds/google-desktop-api.key
 fi
 
 export MOZ_TELEMETRY_REPORTING=1


### PR DESCRIPTION
This environment variables doesn't supported anymore.

This keys must be defined with build flags:
--with-mozilla-api-keyfile
--with-google-api-keyfile