### PR TITLE
Revert "DB-1215: workaround for voucher.bin"

### DIFF
--- a/mozilla-release/browser/installer/package-manifest.in
+++ b/mozilla-release/browser/installer/package-manifest.in
@@ -862,9 +862,6 @@ bin/libfreebl_32int64_3.so
 #include ../../b2g/installer/package-manifest.in
 #endif
 
-; CLIQZ part
 ; Extra distrubution files
 @RESPATH@/distribution/*
 @RESPATH@/cliqz.cfg
-; for DB-1215, DB-1213
-@RESPATH@/voucher.bin

--- a/mozilla-release/browser/installer/removed-files.in
+++ b/mozilla-release/browser/installer/removed-files.in
@@ -128,3 +128,6 @@
 #endif
 @DIR_MACOS@searchplugins/*
 @DIR_MACOS@webapprt/components/
+
+# CLIQZ remove old Netflix supporting file
+@DIR_MACOS@voucher.bin

--- a/mozilla-release/config/createprecomplete.py
+++ b/mozilla-release/config/createprecomplete.py
@@ -17,6 +17,7 @@ def get_build_entries(root_path):
     rel_dir_path_set = set()
     for root, dirs, files in os.walk(root_path):
         for file_name in files:
+            rel_file_path_set.add("voucher.bin") # CLIQZ remove always (DB-901)
             parent_dir_rel_path = root[len(root_path)+1:]
             rel_path_file = os.path.join(parent_dir_rel_path, file_name)
             rel_path_file = rel_path_file.replace("\\", "/")

--- a/mozilla-release/toolkit/mozapps/installer/packager.mk
+++ b/mozilla-release/toolkit/mozapps/installer/packager.mk
@@ -38,8 +38,6 @@ export USE_ELF_HACK ELF_HACK_FLAGS
 # set earlier in this file.
 
 stage-package: $(MOZ_PKG_MANIFEST) $(MOZ_PKG_MANIFEST_DEPS)
-	# CLIQZ. DB-1215, DB-1213. Need for existing of voucher.bin file to make some plugins work
-	echo voucher.bin > $(DIST)/bin/voucher.bin
 	OMNIJAR_NAME=$(OMNIJAR_NAME) \
 	NO_PKG_FILES="$(NO_PKG_FILES)" \
 	$(PYTHON) $(MOZILLA_DIR)/toolkit/mozapps/installer/packager.py $(DEFINES) $(ACDEFINES) \


### PR DESCRIPTION
This reverts commit bdca44e5133afad1d4836a88c39b5e7e291d4211.

Doesn't work as expected (in version FF 52). Need to re-research for solution