### PR TITLE
DB-1276: remove addons section for release build

### DIFF
--- a/mozilla-release/devtools/client/aboutdebugging/components/aboutdebugging.js
+++ b/mozilla-release/devtools/client/aboutdebugging/components/aboutdebugging.js
@@ -11,9 +11,10 @@ const { createFactory, createClass, DOM: dom, PropTypes } =
 const Services = require("Services");
 
 const PanelMenu = createFactory(require("./panel-menu"));
-
+#if MOZ_UPDATE_CHANNEL != release
 loader.lazyGetter(this, "AddonsPanel",
   () => createFactory(require("./addons/panel")));
+#endif
 loader.lazyGetter(this, "TabsPanel",
   () => createFactory(require("./tabs/panel")));
 loader.lazyGetter(this, "WorkersPanel",
@@ -28,11 +29,13 @@ const Strings = Services.strings.createBundle(
   "chrome://devtools/locale/aboutdebugging.properties");
 
 const panels = [{
+#if MOZ_UPDATE_CHANNEL != release
   id: "addons",
   name: Strings.GetStringFromName("addons"),
   icon: "chrome://devtools/skin/images/debugging-addons.svg",
   component: AddonsPanel
 }, {
+#endif
   id: "tabs",
   name: Strings.GetStringFromName("tabs"),
   icon: "chrome://devtools/skin/images/debugging-tabs.svg",
@@ -44,7 +47,11 @@ const panels = [{
   component: WorkersPanel
 }];
 
+#if MOZ_UPDATE_CHANNEL != release
 const defaultPanelId = "addons";
+#else
+const defaultPanelId = "tabs";
+#endif
 
 module.exports = createClass({
   displayName: "AboutDebuggingApp",

--- a/mozilla-release/devtools/client/aboutdebugging/components/moz.build
+++ b/mozilla-release/devtools/client/aboutdebugging/components/moz.build
@@ -9,7 +9,9 @@ DIRS += [
 ]
 
 DevToolsModules(
-    'aboutdebugging.js',
+# DB-1276. For hiding addons on about:debugging page in release build
+# Processing for this file moved to devtools/client/jar.mn
+#   'aboutdebugging.js',
     'panel-header.js',
     'panel-menu-entry.js',
     'panel-menu.js',

--- a/mozilla-release/devtools/client/jar.mn
+++ b/mozilla-release/devtools/client/jar.mn
@@ -332,3 +332,6 @@ devtools.jar:
     skin/images/firebug/command-measure.svg (themes/images/firebug/command-measure.svg)
     skin/images/firebug/command-rulers.svg (themes/images/firebug/command-rulers.svg)
     skin/images/firebug/command-noautohide.svg (themes/images/firebug/command-noautohide.svg)
+
+    # DB-1276. For hiding addons on about:debugging page in release build
+*   modules/devtools/client/aboutdebugging/components/aboutdebugging.js (aboutdebugging/components/aboutdebugging.js)


### PR DESCRIPTION
From about:debugging page. This page will be available only for non-release builds. I think in this task a good idea to remove this page totally, not only "hide" it.