### PR TITLE
DB-1366: fix information on About dialog

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -6,6 +6,7 @@ const Cu = Components.utils;
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource:///modules/CustomizableUI.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("resource://gre/modules/AppConstants.jsm");
 
 const prefs = Cc["@mozilla.org/preferences-service;1"].getService(Ci.nsIPrefBranch);
 
@@ -33,6 +34,11 @@ pref("app.update.certs.1.issuerName", "CN=DigiCert SHA2 Secure Server CA,O=DigiC
 pref("app.update.certs.1.commonName", "*.cliqz.com");
 pref("app.update.certs.2.issuerName", "CN=DigiCert SHA2 Secure Server CA,O=DigiCert Inc,C=US");
 pref("app.update.certs.2.commonName", "*.cliqz.com");
+
+// From distribution.ini (old days)
+lockPref("distribution.id", AppConstants.MOZ_APP_NAME);
+lockPref("distribution.about", "Cliqz");
+lockPref("distribution.version", AppConstants.MOZ_APP_VERSION_DISPLAY);
 
 pref("browser.uitour.enabled", false);
 


### PR DESCRIPTION
This information disappear because we removed distribution.ini file. Now put part of information to cliqz.cfg file.

Related to DB-1353 ticket, removing distribution.ini.

Checked update - it works normally with "Cliqz" as product name.