### PR TITLE
DB-1370: more accurate way to update tile on Start Menu screen

### DIFF
--- a/mozilla-release/browser/installer/windows/nsis/installer.nsi
+++ b/mozilla-release/browser/installer/windows/nsis/installer.nsi
@@ -504,11 +504,12 @@ Section "-Application" APP_IDX
     ${EndIf}
   ${EndIf}
 
-  ; Update lastwritetime of the Start Menu shortcut to clear the tile cache.
+  ; Fake update .lnk file of the Start Menu shortcut to clear the tile cache.
   ${If} ${AtLeastWin8}
   ${AndIf} ${FileExists} "$SMPROGRAMS\${BrandFullName}.lnk"
-    FileOpen $0 "$SMPROGRAMS\${BrandFullName}.lnk" a
-    FileClose $0
+    ShellLink::GetShortCutTarget "$SMPROGRAMS\${BrandFullName}.lnk"
+    Pop $0
+    ShellLink::SetShortCutTarget "$SMPROGRAMS\${BrandFullName}.lnk" $0
   ${EndIf}
 
   ${If} $AddDesktopSC == 1

--- a/mozilla-release/browser/installer/windows/nsis/shared.nsh
+++ b/mozilla-release/browser/installer/windows/nsis/shared.nsh
@@ -73,11 +73,12 @@
   ; root of the Start Menu Programs directory.
   ${MigrateStartMenuShortcut}
 
-  ; Update lastwritetime of the Start Menu shortcut to clear the tile cache.
+  ; Fake update .lnk file of the Start Menu shortcut to clear the tile cache.
   ${If} ${AtLeastWin8}
   ${AndIf} ${FileExists} "$SMPROGRAMS\${BrandFullName}.lnk"
-    FileOpen $0 "$SMPROGRAMS\${BrandFullName}.lnk" a
-    FileClose $0
+    ShellLink::GetShortCutTarget "$SMPROGRAMS\${BrandFullName}.lnk"
+    Pop $0
+    ShellLink::SetShortCutTarget "$SMPROGRAMS\${BrandFullName}.lnk" $0
   ${EndIf}
 
   ; Adds a pinned Task Bar shortcut (see MigrateTaskBarShortcut for details).


### PR DESCRIPTION
For Win8/Win10, on update and upgrade (install on top of previous version).

Also sent a patch to Mozilla (https://bugzilla.mozilla.org/show_bug.cgi?id=1378142)