### PR TITLE
DB-1445: fix tab restoring after browser restart

### DIFF
--- a/mozilla-release/browser/components/sessionstore/SessionStore.jsm
+++ b/mozilla-release/browser/components/sessionstore/SessionStore.jsm
@@ -3198,8 +3198,6 @@ var SessionStoreInternal = {
 
     // update the internal state data for this window
     for (let tab of tabs) {
-      if (tab.private)
-        continue;
       let tabData = TabState.collect(tab);
       tabMap.set(tab, tabData);
       tabsData.push(tabData);


### PR DESCRIPTION
Firefox 55 change a way how they works with restored tabs. Looks like they are not normally initialized as web page at start time. SessionSaver trying to save all tabs. In debugger we moved down to "_collectWindowData: function ssi_collectWindowData(aWindow)", where get an error in condition "if (tab.private)". This is our getter/setter, which was add by Max many versions ago (to track private tab). And now it do not work because loadContext do not created for restored tabs, until they became active (focused). For now we can remove this code, because private tabs will be filtered later in SessionSaver, _saveState function, PrivacyFilter.filterPrivateWindowsAndTabs(state).

In next version we need to review code with our getter/setter private (in tabbrowser.xml)