### PR TITLE
fix: about:home shoudl redirect to about:cliqz

### DIFF
--- a/mozilla-release/browser/components/about/AboutRedirector.cpp
+++ b/mozilla-release/browser/components/about/AboutRedirector.cpp
@@ -83,7 +83,7 @@ static const RedirEntry kRedirMap[] = {
     nsIAboutModule::ALLOW_SCRIPT },
   { "importedtabs", "chrome://browser/content/aboutImportedTabs.xhtml",
     nsIAboutModule::ALLOW_SCRIPT },
-  { "home", "resource://cliqz/freshtab/home.html",
+  { "home", "about:cliqz",
     nsIAboutModule::ALLOW_SCRIPT },
 #if 0
 # Replaced by Cliqz


### PR DESCRIPTION
about:home is not capable to run new tab page, the about:cliqz is doing a redirect to the proper page