### PR TITLE
Allowing legacy extensions

### DIFF
--- a/mozilla-release/browser/config/cliqz.mozconfig
+++ b/mozilla-release/browser/config/cliqz.mozconfig
@@ -13,3 +13,5 @@ ac_add_options --enable-js-shell
 
 export MOZ_APP_PROFILE=CLIQZ
 export MOZ_AUTOMATION_UPLOAD=1
+
+ac_add_options "MOZ_ALLOW_LEGACY_EXTENSIONS=1"


### PR DESCRIPTION
as all addons have to be super signed, allowing legacy extensions is just a way for Cliqz developers to debug `browser-core`