### PR TITLE
DB-1550, DB-1571, DB-1572, DB-1573, DB-1576

### DIFF
--- a/l10n/de/browser/chrome/browser/preferences/preferences.properties
+++ b/l10n/de/browser/chrome/browser/preferences/preferences.properties
@@ -42,7 +42,7 @@ savedLoginsExceptions_desc3=Anmeldedaten für die folgenden Websites werden nich
 
 #### Block List Manager
 
-blockliststext=Liste auswählen, welche Firefox zum Blockieren von deinen Internetaktivitäten verfolgenden Web-Elementen verwenden soll
+blockliststext=Liste auswählen, welche Cliqz zum Blockieren von deinen Internetaktivitäten verfolgenden Web-Elementen verwenden soll
 blockliststitle=Blockierlisten
 # LOCALIZATION NOTE (mozNameTemplate): This template constructs the name of the
 # block list in the block lists dialog. It combines the list name and
@@ -194,7 +194,7 @@ actualAppCacheSize=Dein Anwendungs-Cache belegt derzeit %1$S %2$S Festplatten-Sp
 totalSiteDataSize=Die gespeicherten Websitedaten belegen derzeit %1$S %2$S Speicherplatz.
 loadingSiteDataSize=Durch Websitedaten belegter Speicherplatz wird berechnet…
 clearSiteDataPromptTitle=Alle Cookies und Websitedaten entfernen
-clearSiteDataPromptText="Jetzt leeren" löscht alle Cookies und Websitedaten, die Firefox gespeichert hat. Dadurch wirst du wahrscheinlich von Websites abgemeldet und Offline-Webinhalte werden gelöscht.
+clearSiteDataPromptText="Jetzt leeren" löscht alle Cookies und Websitedaten, die Cliqz gespeichert hat. Dadurch wirst du wahrscheinlich von Websites abgemeldet und Offline-Webinhalte werden gelöscht.
 clearSiteDataNow=Jetzt leeren
 persistent=Dauerhaft
 siteUsage=%1$S %2$S
@@ -274,7 +274,7 @@ searchResults.sorryMessageWin=Keine Treffer in den Einstellungen für "%S".
 searchResults.sorryMessageUnix=Keine Treffer in den Einstellungen für "%S".
 # LOCALIZATION NOTE (searchResults.needHelp2): %1$S is a link to SUMO, %2$S is
 # the browser name
-searchResults.needHelp2=Benötigst du Hilfe? Besuche die <html:a id="need-help-link" target="_blank" href="%1$S">Mozilla Support</html:a>Seite.
+searchResults.needHelp2=Benötigst du Hilfe? Besuche die <html:a id="need-help-link" target="_blank" href="%1$S">Mozilla Support</html:a> Seite.
 
 # LOCALIZATION NOTE %S is the default value of the `dom.ipc.processCount` pref.
 defaultContentProcessCount=%S (Standard)

--- a/l10n/de/browser/chrome/browser/preferences/search.dtd
+++ b/l10n/de/browser/chrome/browser/preferences/search.dtd
@@ -9,8 +9,7 @@
 
 <!ENTITY defaultSearchEngine.label             "Ergänzende Suchmaschine">
 
-<!ENTITY chooseYourDefaultSearchEngine.label   "Wähle deine alternative Suchmaschine. Wenn du mit &brandShortName;’ Vorschlägen nicht zufrieden bist, siehst du deren Ergebnisse wenn du „Enter“ drückst.">
-<!ENTITY chooseYourDefaultSearchEngine2.label  "Wähle Deine alternative Suchmaschine. Wenn Du mit &brandShortName;’ Vorschlägen nicht zufrieden bist, siehst Du deren Ergebnisse wenn Du „Enter“ drückst.">
+<!ENTITY chooseYourDefaultSearchEngine2.label  "Wähle deine alternative Suchmaschine. Wenn du mit &brandShortName;’ Vorschlägen nicht zufrieden bist, siehst du deren Ergebnisse wenn du „Enter“ drückst.">
 <!ENTITY provideSearchSuggestions.label        "Suchvorschläge anzeigen">
 <!ENTITY provideSearchSuggestions.accesskey    "S">
 

--- a/mozilla-release/browser/components/preferences/in-content/privacy.js
+++ b/mozilla-release/browser/components/preferences/in-content/privacy.js
@@ -106,8 +106,6 @@ var gPrivacyPane = {
       }
       var stateCheckbox = document.getElementById("httpsEverywhereEnable");
 
-      document.getElementById("httpsEverywhereGroup").hidden = false;
-
       if (versionChecker.compare(addon.version, FIRST_WEB_EXTENSION_VERSION) >= 0) {
         // HTTPS Everywhere is an web extension
         stateCheckbox.checked = !addon.userDisabled;
@@ -365,10 +363,12 @@ var gPrivacyPane = {
       bundlePrefs.getString("microphonepermissionstitle"),
       bundlePrefs.getString("microphonepermissionstext"),
     ]);
+#if 0
     appendSearchKeywords("addonExceptions", [
       bundlePrefs.getString("addons_permissions_title2"),
       bundlePrefs.getString("addonspermissionstext"),
     ]);
+#endif
     appendSearchKeywords("viewSecurityDevicesButton", [
       pkiBundle.getString("enable_fips"),
     ]);

--- a/mozilla-release/browser/components/preferences/in-content/privacy.xul
+++ b/mozilla-release/browser/components/preferences/in-content/privacy.xul
@@ -597,7 +597,8 @@
     <hbox align="center">
       <checkbox id="trackingProtectionPBM"
                 preference="privacy.donottrackheader.enabled"
-                label="&doNotTrack.description;"/>
+                label="&doNotTrack.description;"
+                class="tail-with-learn-more"/>
       <label class="learnMore text-link"
              href="https://www.mozilla.org/dnt">&doNotTrack.learnMore.label;</label>
     </hbox>
@@ -723,7 +724,7 @@
               searchkeywords="&address2.label; &button.cancel.label; &button.ok.label;"/>
     </hbox>
   </hbox>
-
+#if 0
   <hbox id="addonInstallBox">
     <checkbox id="warnAddonInstall"
               label="&warnOnAddonInstall2.label;"
@@ -745,7 +746,7 @@
                               &button.ok.label;"/>
     </hbox>
   </hbox>
-
+#endif
   <vbox id="a11yPermissionsBox">
     <hbox flex="1" align="center">
       <checkbox id="a11yPrivacyCheckbox" class="tail-with-learn-more"
@@ -849,12 +850,10 @@
             label="&httpsEverywhereEnable.label;"
             accesskey="&httpsEverywhere.accesskey;"
             oncommand="gPrivacyPane.toggleHttpsEverywhere();"/>
-  <hbox align="start">
-    <label>&httpsEverywhereDesc.label;</label>
-    <label class="text-link"
-           style="padding-left: 10px;"
-           value="&httpsEverywhereMore.label;"
-           href="https://www.eff.org/https-everywhere"/>
+  <hbox>
+    <label class="tail-with-learn-more">&httpsEverywhereDesc.label;</label>
+    <label class="learnMore text-link"
+           href="https://www.eff.org/https-everywhere">&httpsEverywhereMore.label;</label>
   </hbox>
 </groupbox>
 

--- a/mozilla-release/browser/locales/en-US/chrome/browser/preferences/preferences.properties
+++ b/mozilla-release/browser/locales/en-US/chrome/browser/preferences/preferences.properties
@@ -42,7 +42,7 @@ savedLoginsExceptions_desc3=Logins for the following websites will not be saved
 
 #### Block List Manager
 
-blockliststext=You can choose which list Firefox will use to block Web elements that may track your browsing activity.
+blockliststext=You can choose which list Cliqz will use to block Web elements that may track your browsing activity.
 blockliststitle=Block Lists
 # LOCALIZATION NOTE (mozNameTemplate): This template constructs the name of the
 # block list in the block lists dialog. It combines the list name and
@@ -193,7 +193,7 @@ actualAppCacheSize=Your application cache is currently using %1$S %2$S of disk s
 totalSiteDataSize=Your stored site data is currently using %1$S %2$S of disk space
 loadingSiteDataSize=Calculating site data size…
 clearSiteDataPromptTitle=Clear all cookies and site data
-clearSiteDataPromptText=Selecting ‘Clear Now’ will clear all cookies and site data stored by Firefox. This may sign you out of websites and remove offline web content.
+clearSiteDataPromptText=Selecting ‘Clear Now’ will clear all cookies and site data stored by Cliqz. This may sign you out of websites and remove offline web content.
 clearSiteDataNow=Clear Now
 persistent=Persistent
 siteUsage=%1$S %2$S

--- a/mozilla-release/toolkit/components/extensions/NativeManifests.jsm
+++ b/mozilla-release/toolkit/components/extensions/NativeManifests.jsm
@@ -29,7 +29,7 @@ const TYPES = {
 
 const NATIVE_MANIFEST_SCHEMA = "chrome://extensions/content/schemas/native_manifest.json";
 
-const REGPATH = "Software\\Mozilla";
+const REGPATH = "Software\\CLIQZ";
 
 this.NativeManifests = {
   _initializePromise: null,


### PR DESCRIPTION
DB-1571: Settings "Learn more" link for HTTPS everywhere is not inline
DB-1573: Remove inactive button in settings to allow websites to install addons
DB-1576: On the page 'about:preferences#connect' there is extra info about HTTPS
DB-1572: In 'Suchergebnisse' in preferences the space between words is missing
DB-1550: Localization