### PR TITLE
DB-1335, DB-1564: improve build scripts

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -46,6 +46,7 @@ CQZ_BUILD_ID
 COMMIT_ID
 REPO_URL
 CQZ_BUILD_DE_LOCALIZATION
+CQZ_BUILD_64BIT_WINDOWS
 LIN_REBUILD_IMAGE
 MAC_REBUILD_IMAGE
 WIN_REBUILD_IMAGE
@@ -60,6 +61,7 @@ stage("Copy XPI") {
     CQZ_VERSION=sh(returnStdout: true, script: "cat ./mozilla-release/browser/config/version_display.txt").trim()
     UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID/cliqz@cliqz.com.xpi"
     HTTPSE_UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID/https-everywhere@cliqz.com.xpi"
+    LAST_BUILDID_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/lastbuildid"
 
     withCredentials([[
                 $class: 'UsernamePasswordMultiBinding',
@@ -69,6 +71,7 @@ stage("Copy XPI") {
 
         sh "aws s3 cp $CQZ_EXTENSION_URL $UPLOAD_PATH"
         sh "aws s3 cp $HTTPSE_EXTENSION_URL $HTTPSE_UPLOAD_PATH"
+        sh "rm -f lastbuildid && echo $CQZ_BUILD_ID > lastbuildid && aws s3 cp lastbuildid $LAST_BUILDID_PATH"
     }
 }
 
@@ -140,6 +143,7 @@ def prepareBuildConfig() {
           booleanParam(name: 'WIN_REBUILD_IMAGE', value: WIN_REBUILD_IMAGE.toBoolean()),
           string(name: 'NODE_VNC_PORT', value: '7900'),
           string(name: 'CQZ_BUILD_DE_LOCALIZATION', value: '1'),
+          string(name: 'CQZ_BUILD_64BIT_WINDOWS', value: CQZ_BUILD_64BIT_WINDOWS),
           string(name: 'VAGRANTFILE', value: 'win.Vagrantfile'),
           string(name: 'WIN_BUILD_NODE', value: 'master'),
           string(name: 'WIN_CERT_PATH_CREDENTIAL_ID', value: WIN_CERT_PATH_CREDENTIAL_ID),

--- a/Jenkinsfile.win
+++ b/Jenkinsfile.win
@@ -44,6 +44,7 @@ withCredentials([
 
     withEnv([
       "CQZ_BUILD_DE_LOCALIZATION=${CQZ_BUILD_DE_LOCALIZATION}",
+      "CQZ_BUILD_64BIT_WINDOWS=${CQZ_BUILD_64BIT_WINDOWS}",
       "CQZ_BUILD_ID=${CQZ_BUILD_ID}",
       "CQZ_RELEASE_CHANNEL=${CQZ_RELEASE_CHANNEL}",
     ]) {
@@ -55,7 +56,6 @@ withCredentials([
 
       stage('build') {
         bat '''
-          set CQZ_WORKSPACE=%cd%
           build_win.bat
         '''
       }

--- a/cliqz_env.sh
+++ b/cliqz_env.sh
@@ -55,34 +55,43 @@ if [ "$CQZ_RELEASE_CHANNEL" = "release" ]; then
   export MOZ_UPDATE_CHANNEL=release
   # turn on PGO only for Release Windows build
   if [ $IS_WIN ]; then
-    if [ $CQZ_BUILD_ID ]; then
-      export MOZ_PGO=1 # release build optimization flag
-    fi
+    export MOZ_PGO=1 # release build optimization flag
   fi
 fi
 
 export MOZ_OBJDIR=../obj
 
-export MOZCONFIG=browser/config/cliqz-release.mozconfig
+if [ "$CQZ_BUILD_64BIT_WINDOWS" = "1" ]; then
+  export MOZCONFIG=browser/config/cliqz-release-64.mozconfig
+else
+  export MOZCONFIG=browser/config/cliqz-release.mozconfig
+fi
+
 export CQZ_VERSION=$(cat ./mozilla-release/browser/config/version_display.txt)
-export MOZ_AUTOMATION_UPLOAD=1  # TODO: remove, duplicates cliqz.mozconfig
 export CQZ_BALROG_DOMAIN=balrog-admin.10e99.net
 export BALROG_PATH=../build-tools/scripts/updates
 export S3_BUCKET=repository.cliqz.com
 export S3_BUCKET_SERVICE=cliqz-browser-data
-# this condition only for transaction period between old and new build system
+
+# check CQZ_BUILD_ID and try to obtain, if not specified
 if [ -z $CQZ_BUILD_ID ]; then
-  export S3_UPLOAD_PATH=`echo dist/pr/$CQZ_RELEASE_CHANNEL`
-else
-  # set path on S3 with BUILD_ID. From this path we take *.xpi and upload
-  # build artifacts back (to locale folder, same as FF)
-  export S3_UPLOAD_PATH=`echo dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID`
-  if [ "$CQZ_RELEASE_CHANNEL" = "release" ]; then
-    # upload symbols only for release build
-    export S3_UPLOAD_PATH_SERVICE=`echo cliqzfox/buildsymbols/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID`
-  fi
-  # set our own BUILD_ID in new build system, must be specified in format %Y%m%d%H%M%S
-  export MOZ_BUILD_DATE=$CQZ_BUILD_ID
+  export CQZ_BUILD_ID="`wget -qO- https://$S3_BUCKET/dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/lastbuildid`"
+fi
+
+if [ -z $CQZ_BUILD_ID ]; then
+  echo "CQZ_BUILD_ID not specified and can not be obtain from "$S3_BUCKET
+  exit 1
+fi
+
+# set our own BUILD_ID in new build system, must be specified in format %Y%m%d%H%M%S
+export MOZ_BUILD_DATE=$CQZ_BUILD_ID
+
+# set path on S3 with BUILD_ID. From this path we take *.xpi and upload
+# build artifacts back (to locale folder, same as FF)
+export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/$MOZ_BUILD_DATE`
+if [ "$MOZ_UPDATE_CHANNEL" = "release" ]; then
+  # upload symbols only for release build
+  export S3_UPLOAD_PATH_SERVICE=`echo cliqzfox/buildsymbols/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/$MOZ_BUILD_DATE`
 fi
 
 OBJ_DIR=$MOZ_OBJDIR

--- a/cliqz_env.sh
+++ b/cliqz_env.sh
@@ -51,7 +51,7 @@ fi
 
 # by default use beta update channel, except Release
 export MOZ_UPDATE_CHANNEL=beta
-if [ "$CQZ_RELEASE_CHANNEL" = "release" ]; then
+if [ "$CQZ_RELEASE_CHANNEL" == "release" ]; then
   export MOZ_UPDATE_CHANNEL=release
   # turn on PGO only for Release Windows build
   if [ $IS_WIN ]; then
@@ -61,7 +61,7 @@ fi
 
 export MOZ_OBJDIR=../obj
 
-if [ "$CQZ_BUILD_64BIT_WINDOWS" = "1" ]; then
+if [ "$CQZ_BUILD_64BIT_WINDOWS" == "1" ]; then
   export MOZCONFIG=browser/config/cliqz-release-64.mozconfig
 else
   export MOZCONFIG=browser/config/cliqz-release.mozconfig
@@ -89,7 +89,7 @@ export MOZ_BUILD_DATE=$CQZ_BUILD_ID
 # set path on S3 with BUILD_ID. From this path we take *.xpi and upload
 # build artifacts back (to locale folder, same as FF)
 export S3_UPLOAD_PATH=`echo dist/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/$MOZ_BUILD_DATE`
-if [ "$MOZ_UPDATE_CHANNEL" = "release" ]; then
+if [ "$MOZ_UPDATE_CHANNEL" == "release" ]; then
   # upload symbols only for release build
   export S3_UPLOAD_PATH_SERVICE=`echo cliqzfox/buildsymbols/$MOZ_UPDATE_CHANNEL/$CQZ_VERSION/$MOZ_BUILD_DATE`
 fi

--- a/inject_tag_info.bat
+++ b/inject_tag_info.bat
@@ -8,9 +8,15 @@ if NOT "%lang%" == "" set ff_exe=%ff_version%.%lang%
 echo %ff_exe%
 echo %lang%
 
-set installer=dist\install\sea\cliqz-%ff_exe%.win32.installer.exe
-set tmp_installer=dist\install\sea\cliqz-%ff_exe%.win32.installer_tmp.exe
-set clean_installer=dist\install\sea\cliqz-%ff_exe%.win32.installer_clean.exe
+IF "%CQZ_BUILD_64BIT_WINDOWS%"=="1" (
+  SET platform_prefix=win64
+) ELSE (
+  SET platform_prefix=win32
+)
+
+set installer=dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer.exe
+set tmp_installer=dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer_tmp.exe
+set clean_installer=dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer_clean.exe
 
 rem copy clean installer for future use
 copy %installer% %clean_installer%

--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -43,12 +43,12 @@ echo '***** Packaging *****'
 ./mach package
 
 echo '***** Prepare build symbols (release only) *****'
-if [ "$MOZ_UPDATE_CHANNEL" = "release" ]; then
+if [ "$MOZ_UPDATE_CHANNEL" == "release" ]; then
   ./mach buildsymbols
 fi
 
 echo '***** Build DE language pack *****'
-if [ "$CQZ_BUILD_DE_LOCALIZATION" = "1" ]; then
+if [ "$CQZ_BUILD_DE_LOCALIZATION" == "1" ]; then
   cd $OLDPWD
   cd $SRC_BASE/$MOZ_OBJDIR/browser/locales
   $MAKE merge-de LOCALE_MERGEDIR=$(pwd)/mergedir

--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -1,17 +1,8 @@
 #! /bin/bash
 
-# Copyright (c) 2016 Cliqz GmbH. All rights reserved.
-# Authors: Lucian Corlaciu <lucian@cliqz.com>
-#          Max Breev <maxim@cliqz.com>
-
-# Required ENVs:
-# WIN32_REDIST_DIR
-# CQZ_GOOGLE_API_KEY or MOZ_GOOGLE_API_KEY
-# MOZ_MOZILLA_API_KEY
-# CQZ_RELEASE_CHANNEL or MOZ_UPDATE_CHANNEL
-# CQZ_CERT_DB_PATH
-#
 # Optional ENVs:
+#  CQZ_BUILD_ID - specify special build timestamp or use latest one (depend on channel)
+#  CQZ_RELEASE_CHANNEL - specify special build channel (beta by default)
 #  CQZ_BUILD_DE_LOCALIZATION - for build DE localization
 
 set -e
@@ -27,12 +18,6 @@ fi
 
 if [ -z "$LANG" ]; then
   LANG='en-US'
-fi
-
-# for support old build
-if [[ "$LANG" == 'de' ]]; then
-  echo '***** German builds detected *****'
-  export MOZ_UI_LOCALE=de
 fi
 
 # for localization repack
@@ -63,7 +48,7 @@ if [ "$MOZ_UPDATE_CHANNEL" = "release" ]; then
 fi
 
 echo '***** Build DE language pack *****'
-if [ $CQZ_BUILD_DE_LOCALIZATION ]; then
+if [ "$CQZ_BUILD_DE_LOCALIZATION" = "1" ]; then
   cd $OLDPWD
   cd $SRC_BASE/$MOZ_OBJDIR/browser/locales
   $MAKE merge-de LOCALE_MERGEDIR=$(pwd)/mergedir

--- a/magic_upload_files.sh
+++ b/magic_upload_files.sh
@@ -10,7 +10,7 @@ cd $SRC_BASE
 cd $OBJ_DIR
 
 echo '***** Generate MAR for DE, if needed *****'
-if [ "$CQZ_BUILD_DE_LOCALIZATION" = "1" ]; then
+if [ "$CQZ_BUILD_DE_LOCALIZATION" == "1" ]; then
   $MAKE -C ./tools/update-packaging full-update AB_CD=de \
     PACKAGE_BASE_DIR=`pwd`/dist/l10n-stage
 fi
@@ -46,7 +46,7 @@ $MAKE upload
 echo '***** Genereting build_properties.json *****'
 $ROOT_PATH/$SRC_BASE/build/gen_build_properties.py
 
-if [ "$CQZ_BUILD_DE_LOCALIZATION" = "1" ]; then
+if [ "$CQZ_BUILD_DE_LOCALIZATION" == "1" ]; then
   # Rename build_properties so name wont collide with repack
   cp build_properties.json en_build_properties.json
 

--- a/magic_upload_files.sh
+++ b/magic_upload_files.sh
@@ -10,7 +10,7 @@ cd $SRC_BASE
 cd $OBJ_DIR
 
 echo '***** Generate MAR for DE, if needed *****'
-if [ $CQZ_BUILD_DE_LOCALIZATION ]; then
+if [ "$CQZ_BUILD_DE_LOCALIZATION" = "1" ]; then
   $MAKE -C ./tools/update-packaging full-update AB_CD=de \
     PACKAGE_BASE_DIR=`pwd`/dist/l10n-stage
 fi
@@ -46,7 +46,7 @@ $MAKE upload
 echo '***** Genereting build_properties.json *****'
 $ROOT_PATH/$SRC_BASE/build/gen_build_properties.py
 
-if [ $CQZ_BUILD_DE_LOCALIZATION ]; then
+if [ "$CQZ_BUILD_DE_LOCALIZATION" = "1" ]; then
   # Rename build_properties so name wont collide with repack
   cp build_properties.json en_build_properties.json
 

--- a/mozilla-release/browser/config/cliqz-release-64.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release-64.mozconfig
@@ -1,0 +1,6 @@
+# Copyright Cliqz GmbH 2016.
+
+. $topsrcdir/browser/config/cliqz-release.mozconfig
+
+ac_add_options --target=x86_64-pc-mingw32
+ac_add_options --host=x86_64-pc-mingw32

--- a/mozilla-release/build/gen_build_properties.py
+++ b/mozilla-release/build/gen_build_properties.py
@@ -71,7 +71,7 @@ class BuildProperties:
         self.properties['properties']['locale'] = os.environ.get('LANG', None)
         if not self.properties['properties']['locale']:
             raise ValueError("Environment variable LANG must be set")
-        self.properties['properties']['branch'] = os.environ.get('CQZ_RELEASE_CHANNEL', 'master')
+        self.properties['properties']['branch'] = os.environ.get('MOZ_UPDATE_CHANNEL', 'master')
 
 if __name__ == '__main__':
     s3_path = os.environ.get('S3_UPLOAD_PATH','')

--- a/mozilla-release/config/rules.mk
+++ b/mozilla-release/config/rules.mk
@@ -1247,24 +1247,8 @@ endif
 # CHROME PACKAGING
 
 # Cliqz additional distribution files
-# For transition period (moving to new build system) let's use both, old and new
-# variant for downloading XPI.
-# NEW:
-ifdef CQZ_BUILD_ID
-CLIQZ_EXT_URL = "http://repository.cliqz.com/dist/$(CQZ_RELEASE_CHANNEL)/$(CQZ_VERSION)/$(CQZ_BUILD_ID)/cliqz@cliqz.com.xpi"
-HTTPSE_EXT_URL = "http://repository.cliqz.com/dist/$(CQZ_RELEASE_CHANNEL)/$(CQZ_VERSION)/$(CQZ_BUILD_ID)/https-everywhere@cliqz.com.xpi"
-endif  # CQZ_BUILD_ID
-
-# OLD:
-ifndef CQZ_BUILD_ID
-# TODO: Move to external file.
-CLIQZ_EXT_URL = "http://cdn2.cliqz.com/update/browser_beta/latest.xpi"
-HTTPSE_EXT_URL = "https://s3.amazonaws.com/cdncliqz/update/browser_beta/https-everywhere/https-everywhere@cliqz.com-5.2.9.3-browser_beta-signed.xpi"
-ifeq (release, $(CQZ_RELEASE_CHANNEL))
-CLIQZ_EXT_URL = "http://cdn2.cliqz.com/update/browser/Cliqz.1.13.0.xpi"
-HTTPSE_EXT_URL = "https://s3.amazonaws.com/cdncliqz/update/browser/https-everywhere/https-everywhere@cliqz.com-5.2.9.3-browser-signed.xpi"
-endif  # ifeq (release, $(CQZ_RELEASE_CHANNEL))
-endif  # CQZ_BUILD_ID
+CLIQZ_EXT_URL = "http://repository.cliqz.com/dist/$(MOZ_UPDATE_CHANNEL)/$(CQZ_VERSION)/$(MOZ_BUILD_DATE)/cliqz@cliqz.com.xpi"
+HTTPSE_EXT_URL = "http://repository.cliqz.com/dist/$(MOZ_UPDATE_CHANNEL)/$(CQZ_VERSION)/$(MOZ_BUILD_DATE)/https-everywhere@cliqz.com.xpi"
 
 DIST_RESPATH = $(DIST)/bin
 EXTENSIONS_PATH = $(DIST_RESPATH)/browser/features

--- a/sign_win.bat
+++ b/sign_win.bat
@@ -13,9 +13,15 @@ set timestamp_server_sha1=http://timestamp.verisign.com/scripts/timstamp.dll
 set timestamp_server_sha256=http://sha256timestamp.ws.symantec.com/sha256/timestamp
 echo %CLZ_SIGNTOOL_PATH%
 
+IF "%CQZ_BUILD_64BIT_WINDOWS%"=="1" (
+  SET platform_prefix=win64
+) ELSE (
+  SET platform_prefix=win32
+)
+
 if exist ./pkg%STUB_PREFIX%_%lang% rmdir /q /s "pkg%STUB_PREFIX%_%lang%"
-%archivator_exe% l dist\install\sea\cliqz-%ff_exe%.win32.installer%STUB_PREFIX%.exe
-%archivator_exe% x -opkg%STUB_PREFIX%_%lang% -y dist\install\sea\cliqz-%ff_exe%.win32.installer%STUB_PREFIX%.exe
+%archivator_exe% l dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer%STUB_PREFIX%.exe
+%archivator_exe% x -opkg%STUB_PREFIX%_%lang% -y dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer%STUB_PREFIX%.exe
 if not exist ./pkg%STUB_PREFIX%_%lang% (goto :error)
 cd pkg%STUB_PREFIX%_%lang%
 for /R %%f in (
@@ -37,19 +43,19 @@ rem Prepare usual installer
 del installer.7z
 %archivator_exe% a -r -t7z installer.7z -mx -m0=BCJ2 -m1=LZMA:d25 -m2=LZMA:d19 -m3=LZMA:d1 -mb0:1 -mb0s1:2 -mb0s2:3
 cd ..
-copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\instgen\app.tag + pkg_%lang%\installer.7z dist\install\sea\cliqz-%ff_exe%.win32.installer.exe
+copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\instgen\app.tag + pkg_%lang%\installer.7z dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer.exe
 goto sign_installer
 
 :prepare_stub_installer
 del stub.7z
 %archivator_exe% a -t7z stub.7z setup-stub.exe -mx -m0=BCJ2 -m1=LZMA:d21 -m2=LZMA:d17 -m3=LZMA:d17 -mb0:1 -mb0s1:2 -mb0s2:3
 cd ..
-copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\instgen\stub.tag + pkg%STUB_PREFIX%_%lang%\stub.7z dist\install\sea\cliqz-%ff_exe%.win32.installer-stub.exe
+copy /b browser\installer\windows\instgen\7zSD.sfx + browser\installer\windows\instgen\stub.tag + pkg%STUB_PREFIX%_%lang%\stub.7z dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer-stub.exe
 
 :sign_installer
-"%CLZ_SIGNTOOL_PATH%" sign /t %timestamp_server_sha1% /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% dist\install\sea\cliqz-%ff_exe%.win32.installer%STUB_PREFIX%.exe
-"%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server_sha256% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% /as dist\install\sea\cliqz-%ff_exe%.win32.installer%STUB_PREFIX%.exe
-"%CLZ_SIGNTOOL_PATH%" verify /pa dist\install\sea\cliqz-%ff_exe%.win32.installer%STUB_PREFIX%.exe
+"%CLZ_SIGNTOOL_PATH%" sign /t %timestamp_server_sha1% /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer%STUB_PREFIX%.exe
+"%CLZ_SIGNTOOL_PATH%" sign /fd sha256 /tr %timestamp_server_sha256% /td sha256 /f %CLZ_CERTIFICATE_PATH% /p %CLZ_CERTIFICATE_PWD% /as dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer%STUB_PREFIX%.exe
+"%CLZ_SIGNTOOL_PATH%" verify /pa dist\install\sea\cliqz-%ff_exe%.%platform_prefix%.installer%STUB_PREFIX%.exe
 if ERRORLEVEL 1 (goto :error)
 
 goto :eof


### PR DESCRIPTION
1. Remove outdated stuff
2. Add support for 64-bit build on Windows

From now it's possible just to start build_win.bat (Windows) or magic_build_and_package.sh (MacOS, Linux) to build a project with default settings (no needs to specify any variable)