### PR TITLE
Record the cookie behavior preference in browser telemetry

### DIFF
--- a/mozilla-release/toolkit/components/telemetry/TelemetryEnvironment.jsm
+++ b/mozilla-release/toolkit/components/telemetry/TelemetryEnvironment.jsm
@@ -250,6 +250,7 @@ const DEFAULT_ENVIRONMENT_PREFS = new Map([
   ["layers.prefer-opengl", {what: RECORD_PREF_VALUE}],
   ["layout.css.devPixelsPerPx", {what: RECORD_PREF_VALUE}],
   ["layout.css.servo.enabled", {what: RECORD_PREF_VALUE}],
+  ["network.cookie.cookieBehavior", {what: RECORD_PREF_VALUE}],
   ["network.proxy.autoconfig_url", {what: RECORD_PREF_STATE}],
   ["network.proxy.http", {what: RECORD_PREF_STATE}],
   ["network.proxy.ssl", {what: RECORD_PREF_STATE}],


### PR DESCRIPTION
Add `network.cookie.cookieBehavior` to default environment prefs in browser telemetry.

@luciancor 