### PR TITLE
Revert "Enable Stylo (#819)"

### DIFF
--- a/mozilla-release/browser/config/cliqz-release.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release.mozconfig
@@ -6,6 +6,7 @@ ac_add_options --enable-update-channel=${MOZ_UPDATE_CHANNEL}
 ac_add_options --enable-release
 ac_add_options --with-mozilla-api-keyfile=../mozilla-desktop-geoloc-api.key
 ac_add_options --with-google-api-keyfile=../google-desktop-api.key
+ac_add_options --disable-stylo
 
 if echo $OSTYPE | grep -q "msys"; then
   # Windows specific flags


### PR DESCRIPTION
This reverts commit 17b976cd407d3f76ac464f36515c670bd8b141f4.
Need more investigation before using in our build. Using stylo increase a build time on Windows and make impossible to generate build symbols on Mac.