### PR TITLE
Revert "DB-1649: enable stylo (#829)"

### DIFF
--- a/mozilla-release/browser/config/cliqz-release.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release.mozconfig
@@ -6,6 +6,7 @@ ac_add_options --enable-update-channel=${MOZ_UPDATE_CHANNEL}
 ac_add_options --enable-release
 ac_add_options --with-mozilla-api-keyfile=../mozilla-desktop-geoloc-api.key
 ac_add_options --with-google-api-keyfile=../google-desktop-api.key
+ac_add_options --disable-stylo
 
 if echo $OSTYPE | grep -q "msys"; then
   # Windows specific flags


### PR DESCRIPTION
This reverts commit 4b284bdd4a7136daa9cbb20553ab640037518380.

We can not build browser on Mac with buildsymbols. Rust version 1.21. dsymutil fall to segmentation fault. FF building Mac version on Linux with cross compiling, they also faced with same problem, it's not possible to gather buildsymbols from code, generated by Rust. Will try to fix this issue later (with minor update probably). Now we need a release build