### PR TITLE
[Do Not Merge] fix mach build tool to build "Android in Artifact Mode" using CLIQZ repository

### DIFF
--- a/mozilla-release/Makefile.in
+++ b/mozilla-release/Makefile.in
@@ -210,7 +210,8 @@ binaries::
 endif
 
 recurse_artifact:
-	$(topsrcdir)/mach --log-no-times artifact install
+	$(topsrcdir)/mach --log-no-times artifact install https://queue.taskcluster.net/v1/task/J-VPXVOPSqOzeAsiLDsTcQ/artifacts/public/build/target.apk
+	$(topsrcdir)/mach --log-no-times artifact install https://queue.taskcluster.net/v1/task/J-VPXVOPSqOzeAsiLDsTcQ/artifacts/public/build/target.common.tests.zip
 
 ifdef MOZ_WIDGET_TOOLKIT
 ifdef ENABLE_TESTS

--- a/mozilla-release/mobile/android/moz.configure
+++ b/mozilla-release/mobile/android/moz.configure
@@ -128,8 +128,9 @@ def check_install_tracking(install_tracking,
             die('You must specify MOZ_NATIVE_DEVICES=1 when'
                 ' building with MOZ_INSTALL_TRACKING=1')
         if not adjust_sdk_keyfile:
-            die('You must specify --with-adjust-sdk-keyfile=/path/to/keyfile when'
-                ' building with MOZ_INSTALL_TRACKING=1')
+            # Using default if Adjust SDK keyfile is not specified
+            # See https://issues.adblockplus.org/ticket/5920
+            adjust_sdk_keyfile = "$topsrcdir/mobile/android/base/adjust-sdk-sandbox.token"
 
 # Must come after the ../../toolkit/moz.configure.
 @depends('MOZ_ANDROID_MMA',

--- a/mozilla-release/python/mozbuild/mozbuild/mach_commands.py
+++ b/mozilla-release/python/mozbuild/mozbuild/mach_commands.py
@@ -1179,9 +1179,11 @@ class PackageFrontend(MachCommandBase):
         if conditions.is_hg(build_obj):
             hg = build_obj.substs['HG']
 
-        git = None
-        if conditions.is_git(build_obj):
-            git = build_obj.substs['GIT']
+        git = '/usr/local/bin/git'
+        if 'GIT' in os.environ:
+            git = os.environ['GIT']
+        # if conditions.is_git(build_obj):
+        #     git = build_obj.substs['GIT']
 
         from mozbuild.artifacts import Artifacts
         artifacts = Artifacts(tree, self.substs, self.defines, job,


### PR DESCRIPTION
Hi Team,

Currently we can't use mach to build "Android in Artifact Mode" using the CLIQZ repository. Because the tool makes certain assumptions e.g checkout from Mercurial, presence of Adjust SDK, which aren't true in our case.

The following changes needs to be done to make it work:

1. Hard-code urls to artifacts that needs to be downloaded. Normally, the tool uses Mercurial revisions to find out which version of the artifacts it's needs to download. As we don't use Mercurial, I would suggest to copy the required artifacts to a static url e.g AWS S3
2. The tool assumes the presence of Adjust SDK, which we are not using. Instead of killing the pipeline, I would recommend to silently ignore the error for the moment
3. Normally, mach should automatically detect that we are using GIT. However this detection is not working. In this case, I have hard-coded a default path which can be changed via env.

@alver-cliqz @spacifici
I would like to ask for your feedback regarding these changes. Can we solve these problems more elegantly?
