### PR TITLE
Check for build dependencies before starting build.

### DIFF
--- a/magic_build_and_package.sh
+++ b/magic_build_and_package.sh
@@ -8,6 +8,14 @@
 set -e
 set -x
 
+# check if dependencies are installed.
+for prog in "wget" "rustc" "zip" "unzip" "yasm"; do
+    if [ -z $(which $prog) ]; then
+       echo "couldnot find build dependency: $prog"
+       exit 1
+    fi
+done
+
 source cliqz_env.sh
 
 cd $SRC_BASE


### PR DESCRIPTION
I found it easier to have this check when I'm starting a build on a clean environment. Would it makes sense to merge to upstream? AFIK this would only work on *NIX style shells, (linux/mac for browser-f).

This checks binary programs that build depends on are present in path
before starting. Assumes a working `which` command.