### PR TITLE
DB-1674: avoid errors when XBL destructors fire without the constructor having fired

### DIFF
--- a/mozilla-release/browser/base/content/urlbarBindings.xml
+++ b/mozilla-release/browser/base/content/urlbarBindings.xml
@@ -142,6 +142,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
       ]]></constructor>
 
       <destructor><![CDATA[
+        // Somehow, it's possible for the XBL destructor to fire without the
+        // constructor ever having fired. Fix:
+        if (!this._prefs) {
+          return;
+        }
         this._prefs.removeObserver("", this);
         this._prefs = null;
         Services.prefs.removeObserver("browser.search.suggest.enabled", this);


### PR DESCRIPTION
Backported firefox fix for https://bugzilla.mozilla.org/show_bug.cgi?id=1434045