### PR TITLE
Unify behavior of urlbar selection on click and double-click for Unix.

### DIFF
--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -293,16 +293,8 @@ pref("browser.showQuitWarning", false);
 pref("browser.fullscreen.autohide", true);
 pref("browser.overlink-delay", 80);
 
-#ifdef UNIX_BUT_NOT_MAC
-pref("browser.urlbar.clickSelectsAll", false);
-#else
 pref("browser.urlbar.clickSelectsAll", true);
-#endif
-#ifdef UNIX_BUT_NOT_MAC
-pref("browser.urlbar.doubleClickSelectsAll", true);
-#else
 pref("browser.urlbar.doubleClickSelectsAll", false);
-#endif
 
 // Control autoFill behavior
 pref("browser.urlbar.autoFill", true);


### PR DESCRIPTION
This default behavior was initially changed to prevent a 16-years old
bug in SeaMonkey, which was already fixed in Firefox since 2007. See
following issues for more details:

* https://bugzilla.mozilla.org/show_bug.cgi?id=190615
* https://bugzilla.mozilla.org/show_bug.cgi?id=611162

This has been tested in the following way:

- Build from source on Ubuntu 16.04
- Tested artifact on Ubuntu and made sure that the behavior is consistent with MacOs