### PR TITLE
DB-1763: remove legacy extension page from about:addons

### DIFF
--- a/mozilla-release/toolkit/mozapps/extensions/content/extensions.js
+++ b/mozilla-release/toolkit/mozapps/extensions/content/extensions.js
@@ -683,9 +683,9 @@ var gViewController = {
 
 #if 0
     this.viewObjects.discover = gDiscoverView;
+    this.viewObjects.legacy = gLegacyView;
 #endif
     this.viewObjects.list = gListView;
-    this.viewObjects.legacy = gLegacyView;
     this.viewObjects.detail = gDetailView;
     this.viewObjects.updates = gUpdatesView;
 
@@ -2291,7 +2291,8 @@ var gLegacyView = {
 
   async refreshVisibility() {
     if (legacyExtensionsEnabled) {
-      this._categoryItem.disabled = true;
+      if (this._categoryItem)
+        this._categoryItem.disabled = true;
       return;
     }
 
@@ -2308,13 +2309,15 @@ var gLegacyView = {
       }
     }
 
-    if (haveLegacy || haveUnsigned) {
-      this._categoryItem.disabled = false;
-      let name = gStrings.ext.GetStringFromName(`type.${haveUnsigned ? "unsupported" : "legacy"}.name`);
-      this._categoryItem.setAttribute("name", name);
-      this._categoryItem.tooltiptext = name;
-    } else {
-      this._categoryItem.disabled = true;
+    if (this._categoryItem) {
+      if (haveLegacy || haveUnsigned) {
+        this._categoryItem.disabled = false;
+        let name = gStrings.ext.GetStringFromName(`type.${haveUnsigned ? "unsupported" : "legacy"}.name`);
+        this._categoryItem.setAttribute("name", name);
+        this._categoryItem.tooltiptext = name;
+      } else {
+        this._categoryItem.disabled = true;
+      }
     }
   },
 

--- a/mozilla-release/toolkit/mozapps/extensions/content/extensions.xul
+++ b/mozilla-release/toolkit/mozapps/extensions/content/extensions.xul
@@ -139,10 +139,10 @@
                       class="category"
                       name="&view.discover.label;" priority="1000"
                       tooltiptext="&view.discover.label;"/>
-#endif
         <richlistitem id="category-legacy" value="addons://legacy/"
                       class="category" priority="20000"
                       disabled="true"/>
+#endif
         <richlistitem id="category-availableUpdates" value="addons://updates/available"
                       class="category"
                       name="&view.availableUpdates.label;" priority="100000"


### PR DESCRIPTION
Please count that in Cliqz browser legacy extension still enabled by default