### PR TITLE
DB-1812: Revert "add template Consentric SystemAddon"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,10 +49,8 @@ properties([
                 name: 'CQZ_EXTENSION_URL'),
         string(defaultValue: "5B0571C810B2BC947DE61ADCE8512CEA605A5625",
                 name: "CQZ_CERT_NAME"),
-        string(defaultValue: 's3://cdncliqz/update/browser_beta/https-everywhere/https-everywhere@cliqz.com-2018.6.21-browser_beta-signed.xpi',
+        string(defaultValue: 's3://cdncliqz/update/browser/https-everywhere/https-everywhere@cliqz.com-5.2.17-browser-signed.xpi',
                 name: 'CQZ_HTTPSE_EXTENSION_URL'),
-        string(defaultValue: 's3://cdncliqz/update/browser/gdprtool@cliqz.com/gdprtool@cliqz.com-0.0.1-browser-signed.xpi',
-                name: 'CQZ_CONSENTRIC_EXTENSION_URL'),
         string(defaultValue: 'us-east-1', name: 'AWS_REGION'),
         string(defaultValue: "c2d53661-8521-47c7-a7b3-73bbb6723c0a",
                 name: "WIN_CERT_PASS_CREDENTIAL_ID"),
@@ -91,7 +89,6 @@ node('docker && us-east-1') {
     stage("Copy XPI") {
         UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/${params.CQZ_VERSION}/${CQZ_BUILD_ID}/cliqz@cliqz.com.xpi"
         HTTPSE_UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/${params.CQZ_VERSION}/${CQZ_BUILD_ID}/https-everywhere@cliqz.com.xpi"
-        CONSENTRIC_UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/${params.CQZ_VERSION}/${CQZ_BUILD_ID}/gdprtool@cliqz.com.xpi"
 
         withCredentials([
             [$class: 'AmazonWebServicesCredentialsBinding',
@@ -101,7 +98,6 @@ node('docker && us-east-1') {
 
             sh "aws s3 cp ${params.CQZ_EXTENSION_URL} $UPLOAD_PATH"
             sh "aws s3 cp ${params.CQZ_HTTPSE_EXTENSION_URL} $HTTPSE_UPLOAD_PATH"
-            sh "aws s3 cp ${params.CQZ_CONSENTRIC_EXTENSION_URL} $CONSENTRIC_UPLOAD_PATH"
         }
     }
 }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -61,7 +61,6 @@ stage("Copy XPI") {
     CQZ_VERSION=sh(returnStdout: true, script: "cat ./mozilla-release/browser/config/version_display.txt").trim()
     UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID/cliqz@cliqz.com.xpi"
     HTTPSE_UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID/https-everywhere@cliqz.com.xpi"
-    CONSENTRIC_UPLOAD_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$CQZ_BUILD_ID/gdprtool@cliqz.com.xpi"
     LAST_BUILDID_PATH="s3://repository.cliqz.com/dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/lastbuildid"
 
     withCredentials([[
@@ -72,7 +71,6 @@ stage("Copy XPI") {
 
         sh "aws s3 cp $CQZ_EXTENSION_URL $UPLOAD_PATH"
         sh "aws s3 cp $HTTPSE_EXTENSION_URL $HTTPSE_UPLOAD_PATH"
-        sh "aws s3 cp $CONSENTRIC_EXTENSION_URL $CONSENTRIC_UPLOAD_PATH"
         sh "rm -f lastbuildid && echo $CQZ_BUILD_ID > lastbuildid && aws s3 cp lastbuildid $LAST_BUILDID_PATH"
     }
 }

--- a/mozilla-release/config/rules.mk
+++ b/mozilla-release/config/rules.mk
@@ -1214,7 +1214,6 @@ endif
 # Cliqz additional distribution files
 CLIQZ_EXT_URL = "http://repository.cliqz.com/dist/$(CQZ_RELEASE_CHANNEL)/$(CQZ_VERSION)/$(MOZ_BUILD_DATE)/cliqz@cliqz.com.xpi"
 HTTPSE_EXT_URL = "http://repository.cliqz.com/dist/$(CQZ_RELEASE_CHANNEL)/$(CQZ_VERSION)/$(MOZ_BUILD_DATE)/https-everywhere@cliqz.com.xpi"
-CONSENTRIC_EXT_URL = "http://repository.cliqz.com/dist/$(CQZ_RELEASE_CHANNEL)/$(CQZ_VERSION)/$(MOZ_BUILD_DATE)/gdprtool@cliqz.com.xpi"
 
 DIST_RESPATH = $(DIST)/bin
 EXTENSIONS_PATH = $(DIST_RESPATH)/browser/features
@@ -1233,13 +1232,6 @@ ifdef HTTPSE_EXT_URL
 	wget --output-document $(HTTPSE_XPI_PATH) $(HTTPSE_EXT_URL)
 endif
 
-CONSENTRIC_XPI_PATH = $(EXTENSIONS_PATH)/gdprtool@cliqz.com.xpi
-$(CONSENTRIC_XPI_PATH): $(EXTENSIONS_PATH)
-ifdef CONSENTRIC_EXT_URL
-	echo CONSENTRIC_XPI_PATH in `pwd`
-	wget --output-document $(CONSENTRIC_XPI_PATH) $(CONSENTRIC_EXT_URL)
-endif
-
 CLIQZ_CFG = $(DIST_RESPATH)/cliqz.cfg
 $(CLIQZ_CFG):
 	echo CLIQZ_CFG in `pwd`
@@ -1247,7 +1239,7 @@ $(CLIQZ_CFG):
 	cp -R $(topsrcdir)/../cliqz.cfg $(DIST_RESPATH)
 
 # Package Cliqz stuff
-cliqz_distr: $(CLIQZ_XPI_PATH) $(HTTPSE_XPI_PATH) $(CONSENTRIC_XPI_PATH) $(CLIQZ_CFG)
+cliqz_distr: $(CLIQZ_XPI_PATH) $(HTTPSE_XPI_PATH) $(CLIQZ_CFG)
 	echo cliqz_distr in `pwd`
 
 chrome::


### PR DESCRIPTION
This reverts commit 9aeca5aa6298a3211974a4aad1bdd8e9dbbd644d.

We don't need it now because we can install it for users with usual SystemAddons update process. Will need it later, after final version of Consentric will be released.