### PR TITLE
DB-1767: Move Cliqz search to the 3rd position below Yahoo

### DIFF
--- a/mozilla-release/browser/locales/search/list.json
+++ b/mozilla-release/browser/locales/search/list.json
@@ -189,7 +189,7 @@
     "de": {
       "default": {
         "visibleDefaultEngines": [
-          "google", "yahoo-de", "bing", "ddg", "youtube-de", "ecosia", "twitter", "amazondotcom-de", "ebay-de", "wikipedia-de", "leo_ende_de", "gmaps-de", "gimages-de", "startpage-de", "qwant", "cliqz-de"
+          "google", "yahoo-de", "cliqz-de", "bing", "ddg", "youtube-de", "ecosia", "twitter", "amazondotcom-de", "ebay-de", "wikipedia-de", "leo_ende_de", "gmaps-de", "gimages-de", "startpage-de", "qwant"
         ]
       }
     },


### PR DESCRIPTION
Sorry @alver-cliqz, got a new request from @oleksandra-cliqz to move the Cliqz search after Yahoo.