### PR TITLE
Revert "DB-1759: API to switch between normal and ultra-private mode"

### DIFF
--- a/mozilla-release/toolkit/components/startup/nsAppStartup.cpp
+++ b/mozilla-release/toolkit/components/startup/nsAppStartup.cpp
@@ -152,8 +152,7 @@ nsAppStartup::nsAppStartup() :
   mInterrupted(false),
   mIsSafeModeNecessary(false),
   mStartupCrashTrackingEnded(false),
-  mRestartNotSameProfile(false),
-  mCliqzPrivateMode(false)
+  mRestartNotSameProfile(false)
 { }
 
 
@@ -400,10 +399,6 @@ nsAppStartup::Quit(uint32_t aMode)
       mRestartNotSameProfile = (aMode & eRestartNotSameProfile) != 0;
     }
 
-    if (!mCliqzPrivateMode) {
-      mCliqzPrivateMode = (aMode & eCliqzPrivateMode) != 0;
-    }
-
     if (mRestart || mRestartNotSameProfile) {
       // Mark the next startup as a restart.
       PR_SetEnv("MOZ_APP_RESTART=1");
@@ -465,15 +460,6 @@ nsAppStartup::Quit(uint32_t aMode)
   }
 
   if (ferocity == eForceQuit) {
-    if (mCliqzPrivateMode) {
-      // Toggle between modes
-      const char *val = PR_GetEnv("MOZ_CLIQZ_PRIVATE_MODE");
-      if (val && *val) {
-        PR_SetEnv("MOZ_CLIQZ_PRIVATE_MODE=");
-      } else {
-        PR_SetEnv("MOZ_CLIQZ_PRIVATE_MODE=1");
-      }
-    }
     // do it!
 
     // No chance of the shutdown being cancelled from here on; tell people

--- a/mozilla-release/toolkit/components/startup/nsAppStartup.h
+++ b/mozilla-release/toolkit/components/startup/nsAppStartup.h
@@ -61,7 +61,6 @@ private:
   bool mIsSafeModeNecessary;       // Whether safe mode is necessary
   bool mStartupCrashTrackingEnded; // Whether startup crash tracking has already ended
   bool mRestartNotSameProfile;     // Quit(eRestartNotSameProfile)
-  bool mCliqzPrivateMode;          // Toggle Cliqz Private Mode
 
 #if defined(XP_WIN)
   //Interaction with OS-provided profiling probes

--- a/mozilla-release/toolkit/components/startup/public/nsIAppStartup.idl
+++ b/mozilla-release/toolkit/components/startup/public/nsIAppStartup.idl
@@ -131,13 +131,6 @@ interface nsIAppStartup : nsISupports
     const uint32_t eRestartNotSameProfile = 0x100;
 
     /**
-     * Switch from normal to ultra-private mode and viceversa. Essentially restart
-     * the application and switch profile. To be used together with eRestartNotSameProfile
-     * and (eAttemptQuit or eForceQuit).
-     */
-    const uint32_t eCliqzPrivateMode = 0x1000;
-
-    /**
      * Exit the event loop, and shut down the app.
      *
      * @param aMode

--- a/mozilla-release/toolkit/xre/nsAppRunner.cpp
+++ b/mozilla-release/toolkit/xre/nsAppRunner.cpp
@@ -240,7 +240,6 @@ extern void InstallSignalHandlers(const char *ProgramName);
 #define FILE_COMPATIBILITY_INFO NS_LITERAL_CSTRING("compatibility.ini")
 #define FILE_INVALIDATE_CACHES NS_LITERAL_CSTRING(".purgecaches")
 #define FILE_STARTUP_INCOMPLETE NS_LITERAL_STRING(".startup-incomplete")
-#define CLIQZ_PRIVATE_MODE_FOLDER NS_LITERAL_CSTRING("cliqzprivatemode")
 
 int    gArgc;
 char **gArgv;
@@ -3139,7 +3138,6 @@ public:
   nsCOMPtr<nsIFile> mProfD;
   nsCOMPtr<nsIFile> mProfLD;
   nsCOMPtr<nsIProfileLock> mProfileLock;
-  nsCOMPtr<nsIProfileLock> mParentProfileLock; // For Cliqz Ultra Private Mode
 #ifdef MOZ_ENABLE_XREMOTE
   nsCOMPtr<nsIRemoteService> mRemoteService;
   nsProfileLock mRemoteLock;
@@ -4331,45 +4329,6 @@ XREMain::XRE_mainStartup(bool* aExitFlag)
   rv = mProfileLock->GetLocalDirectory(getter_AddRefs(mProfLD));
   NS_ENSURE_SUCCESS(rv, 1);
 
-  // Cliqz-specific changes: If ultra-private mode is enabled,
-  // two profiles will be locked, the one that would normally
-  // be selected, and the one that is inside that profile
-  // [normalprofilefolder]/cliqzprivatemode. The latter will be
-  // finally selected, as if the app had been run with --profile.
-  if (EnvHasValue("MOZ_CLIQZ_PRIVATE_MODE")) {
-    // 1. Ensure that [mProfD]/cliqzprivatemode folder exists.
-    nsCOMPtr<nsIFile> profileDir;
-    mProfD->Clone(getter_AddRefs(profileDir));
-    profileDir->AppendNative(CLIQZ_PRIVATE_MODE_FOLDER);
-    bool exists;
-    profileDir->Exists(&exists);
-    if (!exists) {
-      rv = profileDir->Create(nsIFile::DIRECTORY_TYPE, 0700);
-      NS_ENSURE_SUCCESS(rv, 1);
-    }
-    profileDir->IsDirectory(&exists);
-    if (!exists) {
-      return 1;
-    }
-
-    // 2. Lock the cliqzprivatemode profile the same way it is done in SelectProfile for the --profile arg case.
-    nsCOMPtr<nsIProfileUnlocker> unlocker;
-    rv = NS_LockProfilePath(profileDir, profileDir, getter_AddRefs(unlocker), getter_AddRefs(mParentProfileLock));
-    if (!NS_SUCCEEDED(rv)) {
-      return 1;
-    }
-
-    // 3. Swap the mParentProfileLock and mProfileLock.
-    mProfileLock.swap(mParentProfileLock);
-    gProfileLock = mProfileLock;
-
-    // 4. Overwrite mProfD and mProfLD with the final values.
-    rv = mProfileLock->GetDirectory(getter_AddRefs(mProfD));
-    NS_ENSURE_SUCCESS(rv, 1);
-    rv = mProfileLock->GetLocalDirectory(getter_AddRefs(mProfLD));
-    NS_ENSURE_SUCCESS(rv, 1);
-  }
-
   rv = mDirProvider.SetProfile(mProfD, mProfLD);
   NS_ENSURE_SUCCESS(rv, 1);
 
@@ -5058,9 +5017,6 @@ XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig)
   // has gone out of scope.  see bug #386739 for more details
   mProfileLock->Unlock();
   gProfileLock = nullptr;
-  if (mParentProfileLock != nullptr) {
-    mParentProfileLock->Unlock();
-  }
 
   // Restart the app after XPCOM has been shut down cleanly.
   if (appInitiatedRestart) {


### PR DESCRIPTION
This reverts commit 636dceb3efe6e6fff035d2ea36255ac9b95bd403.

We do not need to switch modes anymore.