### PR TITLE
Only disable DNS if proxy settings is set to manual

### DIFF
--- a/mozilla-release/netwerk/dns/nsDNSService2.cpp
+++ b/mozilla-release/netwerk/dns/nsDNSService2.cpp
@@ -631,12 +631,14 @@ nsDNSService::ReadPrefs(const char *name)
         // Disable prefetching either by explicit preference or if a
         // manual proxy is configured
         mDisablePrefetch = true;
-    }
 
-    if (!name || !strcmp(name, kPrefSocksRemoteDns)) {
+        // Disable DNS service if manual proxy is configured and SOCKS
+        // remote DNS preference is set.
         if (NS_SUCCEEDED(Preferences::GetBool(kPrefSocksRemoteDns, &tmpbool))) {
             mDisableDNS = tmpbool;
         }
+    } else {
+        mDisableDNS = false;
     }
     return NS_OK;
 }


### PR DESCRIPTION
This should only disable DNS service if proxy is set to manual AND "proxy DNS through SOCKS" setting is enabled. Right now only the latter is checked.