### PR TITLE
DB-1858: Move urlbar style changes from ui/window.es to browser theme

### DIFF
--- a/mozilla-release/browser/themes/linux/cliqz/theme.css
+++ b/mozilla-release/browser/themes/linux/cliqz/theme.css
@@ -160,6 +160,8 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   transition: background-color cubic-bezier(0.43, -0.01, 0.26, 1.01) 60ms;
   transition-delay: 60ms;
+  max-width: 100%;
+  margin: 0px 0px;
   /* Add 1px margin for page action buttons */
 }
 #navigator-toolbox #nav-bar #urlbar-container #urlbar #page-action-buttons {

--- a/mozilla-release/browser/themes/osx/cliqz/theme.css
+++ b/mozilla-release/browser/themes/osx/cliqz/theme.css
@@ -160,6 +160,8 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   transition: background-color cubic-bezier(0.43, -0.01, 0.26, 1.01) 60ms;
   transition-delay: 60ms;
+  max-width: 100%;
+  margin: 0px 0px;
   /* Add 1px margin for page action buttons */
 }
 #navigator-toolbox #nav-bar #urlbar-container #urlbar #page-action-buttons {

--- a/mozilla-release/browser/themes/windows/cliqz/theme.css
+++ b/mozilla-release/browser/themes/windows/cliqz/theme.css
@@ -160,6 +160,8 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   transition: background-color cubic-bezier(0.43, -0.01, 0.26, 1.01) 60ms;
   transition-delay: 60ms;
+  max-width: 100%;
+  margin: 0px 0px;
   /* Add 1px margin for page action buttons */
 }
 #navigator-toolbox #nav-bar #urlbar-container #urlbar #page-action-buttons {


### PR DESCRIPTION
This is what ui/window module is setting for each window. @luciancor @mai-cliqz Is this ok? Or should this be in a common css instead of one for each platform?