### PR TITLE
Fix | download failed message on AMO - prevent mozaddonmanager

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -207,6 +207,7 @@ if (getenv('MOZ_CLIQZ_PRIVATE_MODE')) {
   pref("browser.pocket.api", "");
   pref("browser.pocket.site", "");
   pref("network.http.referer.hideOnionSource", true);
+  pref("privacy.resistFingerprinting.block_mozAddonManager", true); // Prevent mozaddonmanager on AMO to restore native error message handling for Addons
 
   // Fingerprinting
   pref("webgl.min_capability_mode", true);


### PR DESCRIPTION
AMO uses `window.navigator.mozAddonManager` to handle addon installs/remove in Firefox. This leads to handling of failure messages by AMO not Firefox. Disabling `mozAddonManager` restores the native behaviour of browser on AMO, and failure messages are displayed as before.