### PR TITLE
Enable anti-tracking cookie storage policy by default

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -29,6 +29,9 @@ lockPref("browser.selfsupport.url", "");
 lockPref("privacy.trackingprotection.enabled", false);
 lockPref("privacy.trackingprotection.pbmode.enabled", false);
 
+// Use tracker storage blocking by default. See: https://developer.mozilla.org/en-US/docs/Mozilla/Firefox/Privacy/Storage_access_policy
+pref("network.cookie.cookieBehavior", 4);
+
 // From distribution.ini (old days)
 lockPref("distribution.id", AppConstants.MOZ_APP_NAME);
 lockPref("distribution.about", "Cliqz");


### PR DESCRIPTION
Change default cookie behavior to block storage APIs for trackers by default. Tracking-protection UIs remain disabled.

@alver-cliqz @luciancor @remusao 