### PR TITLE
DB-1926: extending runtime API to include isCliqz

### DIFF
--- a/mozilla-release/toolkit/components/extensions/child/ext-runtime.js
+++ b/mozilla-release/toolkit/components/extensions/child/ext-runtime.js
@@ -120,6 +120,8 @@ this.runtime = class extends ExtensionAPI {
 
         id: extension.id,
 
+        isCliqz: true,
+
         getURL: function(url) {
           return extension.baseURI.resolve(url);
         },

--- a/mozilla-release/toolkit/components/extensions/schemas/runtime.json
+++ b/mozilla-release/toolkit/components/extensions/schemas/runtime.json
@@ -155,6 +155,11 @@
         "type": "string",
         "allowedContexts": ["content", "devtools"],
         "description": "The ID of the extension/app."
+      },
+      "isCliqz": {
+        "type": "boolean",
+        "default": false,
+        "description": "Check if browser is cliqz."
       }
     },
     "functions": [


### PR DESCRIPTION
We need to expose a flag if browser is cliqz in runtime API.
This will be (majorly) consumed by Ghostery extension