### PR TITLE
DB-1915: fixing cookie import erport errors

### DIFF
--- a/mozilla-release/browser/components/migration/FirefoxProfileMigrator.js
+++ b/mozilla-release/browser/components/migration/FirefoxProfileMigrator.js
@@ -479,7 +479,8 @@ FirefoxProfileMigrator.prototype._getResourcesInternal = async function(sourcePr
                                    row.getResultByName("isHttpOnly"),
                                    false,
                                    row.getResultByName("expiry"),
-                                   {});
+                                   {},
+                                   Ci.nsICookie2.SAMESITE_UNSET);
             }
           } finally {
             yield db.close();


### PR DESCRIPTION
Firefox introduced another parameter in `Services.cookies.add` function