### PR TITLE
Improving system addon update

### DIFF
--- a/mozilla-release/toolkit/mozapps/extensions/AddonManager.jsm
+++ b/mozilla-release/toolkit/mozapps/extensions/AddonManager.jsm
@@ -1282,6 +1282,9 @@ var AddonManagerInternal = {
         await AddonRepository.backgroundUpdateCheck();
 
         for (let addon of allAddons) {
+          // CLIQZ-SPECIAL: skip the system addons update check. we update them via function after this loop
+          if (addon.signedState === AddonManager.SIGNEDSTATE_SYSTEM)
+            continue;
           // Check all add-ons for updates so that any compatibility updates will
           // be applied
           updates.push(new Promise((resolve, reject) => {


### PR DESCRIPTION
Firefox checks update for every addon via `update_url` or `versioncheck-bg.addons.mozilla.org` this includes system addons too, which ideally should not be included(they don't install just check for update `¯\_(ツ)_/¯`  )
They update system addons via separate process (`AddonManagerInternal._getProviderByName("XPIProvider").updateSystemAddons()`). So skipping update check for system addons and avoiding unnecessary overhead.