### PR TITLE
DB-2042: URL Bar focus issue

### DIFF
--- a/mozilla-release/browser/components/sessionstore/SessionStore.jsm
+++ b/mozilla-release/browser/components/sessionstore/SessionStore.jsm
@@ -4130,7 +4130,7 @@ var SessionStoreInternal = {
        requestTime: Services.telemetry.msSystemNow()});
 
     // Focus the tab's content area.
-    if (aTab.selected && !window.isBlankPageURL(uri)) {
+    if (aTab.selected && !window.isBlankPageURL(uri) && !uri.startsWith("moz-extension")) {
       browser.focus();
     }
   },


### PR DESCRIPTION
This fix prevents focus to go to browser content in case of delayed startup(for Cliqz its case for every freshtab)