### PR TITLE
DB-2101: fix for build with MSVC on Windows

### DIFF
--- a/build_win.bat
+++ b/build_win.bat
@@ -90,6 +90,11 @@ IF "%CQZ_BUILD_64BIT_WINDOWS%"=="1" (
 ) ELSE (
   SET WIN32_REDIST_DIR=c:\build\redist\msvc\x86\
   SET WIN_UCRT_REDIST_DIR=c:\build\redist\ucrt\DLLs\x86\
+  ECHO !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  ECHO !! Remove after merge with Firefox 67.0 !!
+  ECHO !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  SET LINKER=C:/PROGRA~2/MICROS~1/2017/PROFES~1/VC/Tools/MSVC/1415~1.267/bin/HostX64/x86/link.exe
+  SET HOST_LINKER=C:/PROGRA~2/MICROS~1/2017/PROFES~1/VC/Tools/MSVC/1415~1.267/bin/HostX64/x86/link.exe
 )
 
 :::::::::::::::::::::::::::::::::::

--- a/mozilla-release/browser/config/cliqz-release.mozconfig
+++ b/mozilla-release/browser/config/cliqz-release.mozconfig
@@ -21,3 +21,6 @@ export MOZ_REQUIRE_SIGNING=1
 # safeguard against someone forgetting to re-set EARLY_BETA_OR_EARLIER in
 # defines.sh during the beta cycle
 export BUILDING_RELEASE=1
+
+ac_add_options --target=i686-pc-mingw32
+ac_add_options --host=i686-pc-mingw32


### PR DESCRIPTION
This is fix for Firefox 66.0 only, must be removed after merging with Firefox 67.0