### PR TITLE
DB-2142: preventing third party website warning(enabling mozaddonmanager

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -56,9 +56,6 @@ lockPref("browser.search.widget.inNavBar", false);
 // Turn off thumbnails for New Tab (not used in Cliqz browser)
 pref("browser.pagethumbnails.capturing_disabled", true);
 
-// DB-1879 | Prevent mozaddonmanager on AMO to restore native error message handling for Addons DB 
-pref("privacy.resistFingerprinting.block_mozAddonManager", true);
-
 try {
   prefs.getBoolPref("extensions.cliqz.listed");
 } catch (e) {


### PR DESCRIPTION
Before 1.24 Cliqz did not allow installation of addons, so we did not require `mozaddonmanager` and it caused issues when one opens addons.mozilla.org (see DB-1879) 
from 1.24 we allowed installation of Mozilla signed addon, now we must include mozaddonmanager in order to streamline installation and avoid third party website warning.