### PR TITLE
DB-2208: added a private attribute for tabs

### DIFF
--- a/mozilla-release/browser/base/content/PrivateTabUI.jsm
+++ b/mozilla-release/browser/base/content/PrivateTabUI.jsm
@@ -57,6 +57,8 @@ const eventHandlers = {
   "TabPrivateModeChanged": function onTabPrivateModeChanged(event) {
     if (event.originalTarget !== this._browser.selectedBrowser)
       return;
+
+    this._browser.selectedTab.setAttribute("private", event.detail.private == true);
     this._setToolboxPrivateAttr(event.detail.private);
   }
 };

--- a/mozilla-release/browser/base/content/browser.js
+++ b/mozilla-release/browser/base/content/browser.js
@@ -2646,6 +2646,7 @@ function BrowserOpenTab(event) {
       openTrustedLinkIn(BROWSER_NEW_TAB_URL, where, {
         relatedToCurrent,
         resolveOnNewTabCreated: resolve,
+        private: false,
       });
     }),
   }, "browser-open-newtab-start");

--- a/mozilla-release/browser/base/content/browser.js
+++ b/mozilla-release/browser/base/content/browser.js
@@ -2646,7 +2646,7 @@ function BrowserOpenTab(event) {
       openTrustedLinkIn(BROWSER_NEW_TAB_URL, where, {
         relatedToCurrent,
         resolveOnNewTabCreated: resolve,
-        private: false,
+        private: PrivateBrowsingUtils.isWindowPrivate(window),
       });
     }),
   }, "browser-open-newtab-start");

--- a/mozilla-release/browser/base/content/tabbrowser.js
+++ b/mozilla-release/browser/base/content/tabbrowser.js
@@ -362,6 +362,11 @@ window._gBrowser = {
       ContextualIdentityService.setTabStyle(tab);
     }
 
+    // CLIQZ-SPECIAL:
+    // DB-2208:
+    // The idea to do that does not look nice but what an adventure! ;)
+    tab.setAttribute("private", window.arguments[0] === "about:privatebrowsing");
+
     this._tabForBrowser.set(browser, tab);
 
     this._appendStatusPanel();
@@ -2257,6 +2262,8 @@ window._gBrowser = {
    */
   addTrustedTab(aURI, params = {}) {
     params.triggeringPrincipal = Services.scriptSecurityManager.getSystemPrincipal();
+    params.private = typeof params.private == "boolean" ? params.private : false;
+
     return this.addTab(aURI, params);
   },
 
@@ -2329,6 +2336,8 @@ window._gBrowser = {
       (relatedToCurrent && this.selectedTab));
 
     var t = document.createXULElement("tab");
+
+    t.setAttribute("private", private == true);
 
     t.openerTab = openerTab;
 

--- a/mozilla-release/browser/base/content/utilityOverlay.js
+++ b/mozilla-release/browser/base/content/utilityOverlay.js
@@ -316,7 +316,7 @@ function openLinkIn(url, where, params) {
   var aForceAllowDataURI    = params.forceAllowDataURI;
   var aInBackground         = params.inBackground;
   var aInitiatingDoc        = params.initiatingDoc;
-  var aIsPrivate            = params.private || params.isContentWindowPrivate;
+  var aIsPrivate            = params.private || params.isContentWindowPrivate || false;
   var aSkipTabAnimation     = params.skipTabAnimation;
   var aAllowPinnedTabHostChange = !!params.allowPinnedTabHostChange;
   var aAllowPopups          = !!params.allowPopups;

--- a/mozilla-release/browser/components/extensions/parent/ext-browser.js
+++ b/mozilla-release/browser/components/extensions/parent/ext-browser.js
@@ -25,6 +25,10 @@ let tabTracker;
 let windowTracker;
 
 function isPrivateTab(nativeTab) {
+  if (nativeTab.linkedBrowser.loadContext == null) {
+    return nativeTab.getAttribute("private") === "true";
+  }
+
   return PrivateBrowsingUtils.isBrowserPrivate(nativeTab.linkedBrowser);
 }
 
@@ -701,7 +705,7 @@ Object.assign(global, {tabTracker, windowTracker});
 
 class Tab extends TabBase {
   get incognito() {
-    return PrivateBrowsingUtils.isBrowserPrivate(this.browser);
+    return isPrivateTab(this.nativeTab);
   }
 
   get _favIconUrl() {

--- a/mozilla-release/browser/components/sessionstore/SessionStore.jsm
+++ b/mozilla-release/browser/components/sessionstore/SessionStore.jsm
@@ -2642,11 +2642,12 @@ var SessionStoreInternal = {
     // Create a new tab.
     // Cliqz. DB-919: Added aTab.private param into addTab so that new tab will be private
     // if it's duplicated from a private tab
+    let aPrivate = aTab.getAttribute("private") === "true";
     let userContextId = aTab.getAttribute("usercontextid");
 
     let tabOptions = {
       userContextId,
-      ...(aTab == aWindow.gBrowser.selectedTab ? {relatedToCurrent: true, ownerTab: aTab, private: aTab.private} : {private: aTab.private}),
+      ...(aTab == aWindow.gBrowser.selectedTab ? {relatedToCurrent: true, ownerTab: aTab, private: aPrivate} : {private: aPrivate}),
     };
     let newTab = aWindow.gBrowser.addTrustedTab(null, tabOptions);
 


### PR DESCRIPTION
In this PR I added a "private" attribute for a tab xul element.
Whenever the extension requests a status of a tab first we check whether the tab has contents loaded into that (linkedBrowser.loadContext is not null). If it does not then we rely on the "private" attribute value. Otherwise we define privacy on linkedBrowser.loadContext.