### PR TITLE
DB-2218: exempt system addons from blocklist

### DIFF
--- a/mozilla-release/toolkit/mozapps/extensions/Blocklist.jsm
+++ b/mozilla-release/toolkit/mozapps/extensions/Blocklist.jsm
@@ -1357,6 +1357,10 @@ var BlocklistXML = {
     if (!gBlocklistEnabled)
       return null;
 
+    // CLIQZ-SPECIAL: Exempt system-addons from being blocklisted
+    if (addon.isSystem)
+      return null;
+
     // Not all applications implement nsIXULAppInfo (e.g. xpcshell doesn't).
     if (!appVersion && !gAppVersion)
       return null;


### PR DESCRIPTION
This PR ensures no system addon can be disabled by blocklist.
We maintain list/update of system addon and we know we never want to block any system addon.