### PR TITLE
DB-2234: add tab privacy check | fixed loadContext error

### DIFF
--- a/mozilla-release/browser/base/content/browser-contentblocking.js
+++ b/mozilla-release/browser/base/content/browser-contentblocking.js
@@ -1120,7 +1120,7 @@ var ContentBlocking = {
       anyBlocking = anyBlocking || blocker.activated;
     }
 
-    let isBrowserPrivate = PrivateBrowsingUtils.isBrowserPrivate(gBrowser.selectedBrowser);
+    let isBrowserPrivate = PrivateBrowsingUtils.isTabContextPrivate(gBrowser.getTabForBrowser(gBrowser.selectedBrowser));
 
     // Check whether the user has added an exception for this site.
     let type =  isBrowserPrivate ? "trackingprotection-pb" : "trackingprotection";
@@ -1214,7 +1214,7 @@ var ContentBlocking = {
     // Add the current host in the 'trackingprotection' consumer of
     // the permission manager using a normalized URI. This effectively
     // places this host on the tracking protection allowlist.
-    if (PrivateBrowsingUtils.isBrowserPrivate(gBrowser.selectedBrowser)) {
+    if (PrivateBrowsingUtils.isTabContextPrivate(gBrowser.getTabForBrowser(gBrowser.selectedBrowser))) {
       PrivateBrowsingUtils.addToTrackingAllowlist(baseURI);
     } else {
       Services.perms.add(baseURI,
@@ -1230,7 +1230,7 @@ var ContentBlocking = {
     // from the tracking protection allowlist.
     let baseURI = this._baseURIForChannelClassifier;
 
-    if (PrivateBrowsingUtils.isBrowserPrivate(gBrowser.selectedBrowser)) {
+    if (PrivateBrowsingUtils.isTabContextPrivate(gBrowser.getTabForBrowser(gBrowser.selectedBrowser))) {
       PrivateBrowsingUtils.removeFromTrackingAllowlist(baseURI);
     } else {
       Services.perms.remove(baseURI, "trackingprotection");
@@ -1240,7 +1240,7 @@ var ContentBlocking = {
   },
 
   dontShowIntroPanelAgain() {
-    if (!PrivateBrowsingUtils.isBrowserPrivate(gBrowser.selectedBrowser)) {
+    if (!PrivateBrowsingUtils.isTabContextPrivate(gBrowser.getTabForBrowser(gBrowser.selectedBrowser))) {
       Services.prefs.setIntPref(this.prefIntroCount, this.MAX_INTROS);
       Services.prefs.savePrefFile(null);
     }

--- a/mozilla-release/browser/base/content/browser.js
+++ b/mozilla-release/browser/base/content/browser.js
@@ -1359,9 +1359,10 @@ function _loadURI(browser, uri, params = {}) {
   try {
     if (!mustChangeProcess) {
       if (userContextId) {
+        let aTab = browser.ownerGlobal.gBrowser.getTabForBrowser(browser);
         browser.webNavigation.setOriginAttributesBeforeLoading({
           userContextId,
-          privateBrowsingId: PrivateBrowsingUtils.isBrowserPrivate(browser) ? 1 : 0,
+          privateBrowsingId: PrivateBrowsingUtils.isTabContextPrivate(aTab) ? 1 : 0,
         });
       }
       if (CliqzResources.isCliqzPage(uri)) {
@@ -1412,9 +1413,10 @@ function _loadURI(browser, uri, params = {}) {
       gBrowser.updateBrowserRemotenessByURL(browser, uri);
 
       if (userContextId) {
+        let aTab = browser.ownerGlobal.gBrowser.getTabForBrowser(browser);
         browser.webNavigation.setOriginAttributesBeforeLoading({
           userContextId,
-          privateBrowsingId: PrivateBrowsingUtils.isBrowserPrivate(browser) ? 1 : 0,
+          privateBrowsingId: PrivateBrowsingUtils.isTabContextPrivate(aTab) ? 1 : 0,
         });
       }
       browser.webNavigation.loadURI(uri, loadURIOptions);
@@ -3038,7 +3040,8 @@ function URLBarSetURI(aURI, updatePopupNotifications) {
 
     // Cliqz. Invalidate page proxy state for inital pages opened in private tabs
     // and Cliqz pages.
-    if (PrivateBrowsingUtils.isBrowserPrivate(gBrowser.selectedBrowser) &&
+    let aTab = gBrowser.getTabForBrowser(gBrowser.selectedBrowser);
+    if (PrivateBrowsingUtils.isTabContextPrivate(aTab) &&
         CliqzResources.isInitialPage(uri.spec)) {
       valid = false;
     }
@@ -3404,7 +3407,8 @@ var BrowserOnClick = {
           flags |= overrideService.ERROR_TIME;
         }
         let uri = Services.uriFixup.createFixupURI(location, 0);
-        let permanentOverride = !PrivateBrowsingUtils.isBrowserPrivate(browser) && Services.prefs.getBoolPref("security.certerrors.permanentOverride");
+        let aTab = browser.ownerGlobal.gBrowser.getTabForBrowser(browser);
+        let permanentOverride = !PrivateBrowsingUtils.isTabContextPrivate(aTab) && Services.prefs.getBoolPref("security.certerrors.permanentOverride");
         cert = securityInfo.serverCert;
         overrideService.rememberValidityOverride(
           uri.asciiHost, uri.port,

--- a/mozilla-release/browser/base/content/nsContextMenu.js
+++ b/mozilla-release/browser/base/content/nsContextMenu.js
@@ -1029,7 +1029,8 @@ nsContextMenu.prototype = {
 
   saveVideoFrameAsImage() {
     let mm = this.browser.messageManager;
-    let isPrivate = PrivateBrowsingUtils.isBrowserPrivate(this.browser);
+    let aTab = this.browser.ownerGlobal.gBrowser.getTabForBrowser(this.browser);
+    let isPrivate = PrivateBrowsingUtils.isTabContextPrivate(aTab);
 
     let name = "";
     if (this.mediaURL) {
@@ -1242,7 +1243,8 @@ nsContextMenu.prototype = {
     if (linkDownload)
       channel.contentDispositionFilename = linkDownload;
     if (channel instanceof Ci.nsIPrivateBrowsingChannel) {
-      let docIsPrivate = PrivateBrowsingUtils.isBrowserPrivate(this.browser);
+      let aTab = this.browser.ownerGlobal.gBrowser.getTabForBrowser(this.browser);
+      let docIsPrivate = PrivateBrowsingUtils.isTabContextPrivate(aTab);
       channel.setPrivate(docIsPrivate);
     }
     channel.notificationCallbacks = new callbacks();
@@ -1300,7 +1302,8 @@ nsContextMenu.prototype = {
     let doc = this.ownerDoc;
     let isContentWindowPrivate = this.isRemote ? this.ownerDoc.isPrivate : undefined;
     let referrerURI = gContextMenuContentData.documentURIObject;
-    let isPrivate = PrivateBrowsingUtils.isBrowserPrivate(this.browser);
+    let aTab = this.browser.ownerGlobal.gBrowser.getTabForBrowser(this.browser);
+    let isPrivate = PrivateBrowsingUtils.isTabContextPrivate(aTab);
     if (this.onCanvas) {
       // Bypass cache, since it's a data: URL.
       this._canvasToBlobURL(this.target).then(function(blobURL) {

--- a/mozilla-release/browser/base/content/tabbrowser.js
+++ b/mozilla-release/browser/base/content/tabbrowser.js
@@ -5227,7 +5227,7 @@ class TabProgressListener {
       // CLIQZ: also don't register windows from Forget tabs.
       if (!isBlankPageURL(aLocation.spec) &&
           ((!PrivateBrowsingUtils.isWindowPrivate(window) &&
-            !PrivateBrowsingUtils.isBrowserPrivate(this.mTab.linkedBrowser)) ||
+            !PrivateBrowsingUtils.isTabContextPrivate(this.mTab)) ||
             PrivateBrowsingUtils.permanentPrivateBrowsing)) {
         gBrowser.UrlbarProviderOpenTabs.registerOpenTab(aLocation.spec,
                                                         userContextId);

--- a/mozilla-release/browser/components/extensions/parent/ext-browser.js
+++ b/mozilla-release/browser/components/extensions/parent/ext-browser.js
@@ -25,11 +25,7 @@ let tabTracker;
 let windowTracker;
 
 function isPrivateTab(nativeTab) {
-  if (nativeTab.linkedBrowser.loadContext == null) {
-    return nativeTab.getAttribute("private") === "true";
-  }
-
-  return PrivateBrowsingUtils.isBrowserPrivate(nativeTab.linkedBrowser);
+  return PrivateBrowsingUtils.isTabContextPrivate(nativeTab);
 }
 
 function isPrivateWindow(window) {

--- a/mozilla-release/browser/components/extensions/parent/ext-find.js
+++ b/mozilla-release/browser/components/extensions/parent/ext-find.js
@@ -28,7 +28,7 @@ function runFindOperation(context, params, message) {
   let mm = browser.messageManager;
   tabId = tabId || tabTracker.getId(tab);
   if (!context.privateBrowsingAllowed &&
-      PrivateBrowsingUtils.isBrowserPrivate(browser)) {
+      PrivateBrowsingUtils.isTabContextPrivate(tab)) {
     return Promise.reject({message: `Unable to search: ${tabId}`});
   }
   // We disallow find in about: urls.
@@ -116,7 +116,7 @@ this.find = class extends ExtensionAPI {
          */
         removeHighlighting(tabId) {
           let tab = tabId ? tabTracker.getTab(tabId) : tabTracker.activeTab;
-          if (!context.privateBrowsingAllowed && PrivateBrowsingUtils.isBrowserPrivate(tab.linkedBrowser)) {
+          if (!context.privateBrowsingAllowed && PrivateBrowsingUtils.isTabContextPrivate(tab)) {
             throw new ExtensionError(`Invalid tab ID: ${tabId}`);
           }
           tab.linkedBrowser.messageManager.sendAsyncMessage("ext-Finder:clearHighlighting");

--- a/mozilla-release/browser/components/extensions/parent/ext-menus.js
+++ b/mozilla-release/browser/components/extensions/parent/ext-menus.js
@@ -103,7 +103,7 @@ var gMenuBuilder = {
   canAccessContext(extension, contextData) {
     if (!extension.privateBrowsingAllowed) {
       let nativeTab = contextData.tab;
-      if (nativeTab && PrivateBrowsingUtils.isBrowserPrivate(nativeTab.linkedBrowser)) {
+      if (nativeTab && PrivateBrowsingUtils.isTabContextPrivate(nativeTab)) {
         return false;
       } else if (PrivateBrowsingUtils.isWindowPrivate(contextData.menu.ownerGlobal)) {
         return false;

--- a/mozilla-release/browser/components/extensions/parent/ext-tabs.js
+++ b/mozilla-release/browser/components/extensions/parent/ext-tabs.js
@@ -582,7 +582,7 @@ this.tabs = class extends ExtensionAPI {
               // Falling back to codebase here as about: requires it, however is safe.
               principal = Services.scriptSecurityManager.createCodebasePrincipal(Services.io.newURI(url), {
                 userContextId: options.userContextId,
-                privateBrowsingId: PrivateBrowsingUtils.isBrowserPrivate(window.gBrowser) ? 1 : 0,
+                privateBrowsingId: PrivateBrowsingUtils.isBrowserPrivate(window.gBrowser, true) ? 1 : 0,
               });
             } else {
               options.allowInheritPrincipal = true;
@@ -872,8 +872,8 @@ this.tabs = class extends ExtensionAPI {
             // If moving between windows, be sure privacy matches.  While gBrowser
             // prevents this, we want to silently ignore it.
             if (nativeTab.ownerGlobal != window &&
-                PrivateBrowsingUtils.isBrowserPrivate(window.gBrowser) !=
-                PrivateBrowsingUtils.isBrowserPrivate(nativeTab.ownerGlobal.gBrowser)) {
+                PrivateBrowsingUtils.isBrowserPrivate(window.gBrowser, true) !=
+                PrivateBrowsingUtils.isBrowserPrivate(nativeTab.ownerGlobal.gBrowser, true)) {
               continue;
             }
 

--- a/mozilla-release/browser/components/extensions/parent/ext-windows.js
+++ b/mozilla-release/browser/components/extensions/parent/ext-windows.js
@@ -169,7 +169,7 @@ this.windows = class extends ExtensionAPI {
             }
             // Private browsing tabs can only be moved to private browsing
             // windows.
-            let incognito = PrivateBrowsingUtils.isBrowserPrivate(tab.linkedBrowser);
+            let incognito = PrivateBrowsingUtils.isTabContextPrivate(tab);
             if (createData.incognito !== null && createData.incognito != incognito) {
               return Promise.reject({message: "`incognito` property must match the incognito state of tab"});
             }

--- a/mozilla-release/browser/components/newtab/lib/BookmarkPanelHub.jsm
+++ b/mozilla-release/browser/components/newtab/lib/BookmarkPanelHub.jsm
@@ -198,7 +198,8 @@ class _BookmarkPanelHub {
 
   sendUserEventTelemetry(event, win) {
     // Only send pings for non private browsing windows
-    if (!PrivateBrowsingUtils.isBrowserPrivate(win.ownerGlobal.gBrowser.selectedBrowser)) {
+    const aTab = win.ownerGlobal.gBrowser.getTabForBrowser(win.ownerGlobal.gBrowser.selectedBrowser);
+    if (!PrivateBrowsingUtils.isTabContextPrivate(aTab)) {
       this._sendTelemetry({message_id: this._response.id, bucket_id: this._response.id, event});
     }
   }

--- a/mozilla-release/browser/components/places/PlacesUIUtils.jsm
+++ b/mozilla-release/browser/components/places/PlacesUIUtils.jsm
@@ -183,7 +183,7 @@ let InternalFaviconLoader = {
     }
 
     // First we do the actual setAndFetch call:
-    let loadType = PrivateBrowsingUtils.isBrowserPrivate(browser)
+    let loadType = PrivateBrowsingUtils.isTabContextPrivate(win.ownerGlobal.gBrowser.getTabForBrowser(browser))
       ? PlacesUtils.favicons.FAVICON_LOAD_PRIVATE
       : PlacesUtils.favicons.FAVICON_LOAD_NON_PRIVATE;
     let callback = this._makeCompletionCallback(win, innerWindowID);

--- a/mozilla-release/browser/modules/ContentSearch.jsm
+++ b/mozilla-release/browser/modules/ContentSearch.jsm
@@ -273,7 +273,7 @@ var ContentSearch = {
     let ok = SearchSuggestionController.engineOffersSuggestions(engine);
     controller.maxLocalResults = ok ? MAX_LOCAL_SUGGESTIONS : MAX_SUGGESTIONS;
     controller.maxRemoteResults = ok ? MAX_SUGGESTIONS : 0;
-    let priv = PrivateBrowsingUtils.isBrowserPrivate(browser);
+    let priv = PrivateBrowsingUtils.isTabContextPrivate(browser.ownerGlobal.gBrowser.getTabForBrowser(browser));
     // fetch() rejects its promise if there's a pending request, but since we
     // process our event queue serially, there's never a pending request.
     this._currentSuggestion = { controller, target: browser };
@@ -307,7 +307,7 @@ var ContentSearch = {
       // isBrowserPrivate assumes that the passed-in browser has all the normal
       // properties, which won't be true if the browser has been destroyed.
       // That may be the case here due to the asynchronous nature of messaging.
-      isPrivate = PrivateBrowsingUtils.isBrowserPrivate(browser.target);
+      isPrivate = PrivateBrowsingUtils.isTabContextPrivate(browser.target.ownerGlobal.gBrowser.getTabForBrowser(browser.target));
     } catch (err) {
       return false;
     }

--- a/mozilla-release/browser/modules/PermissionUI.jsm
+++ b/mozilla-release/browser/modules/PermissionUI.jsm
@@ -436,7 +436,7 @@ var PermissionPromptPrototype = {
               // Permanently store permission.
               let scope = SitePermissions.SCOPE_PERSISTENT;
               // Only remember permission for session if in PB mode.
-              if (PrivateBrowsingUtils.isBrowserPrivate(this.browser)) {
+              if (PrivateBrowsingUtils.isTabContextPrivate(chromeWin.gBrowser.getTabForBrowser(this.browser))) {
                 scope = SitePermissions.SCOPE_SESSION;
               }
               SitePermissions.set(this.principal.URI,
@@ -525,7 +525,7 @@ var PermissionPromptPrototype = {
           // by permanent entries in the permission manager.
           let scope = SitePermissions.SCOPE_PERSISTENT;
           // Only remember permission for session if in PB mode.
-          if (PrivateBrowsingUtils.isBrowserPrivate(browser)) {
+          if (PrivateBrowsingUtils.isTabContextPrivate(chromeWin.gBrowser.getTabForBrowser(browser))) {
             scope = SitePermissions.SCOPE_SESSION;
           }
           SitePermissions.set(principal.URI,
@@ -816,7 +816,7 @@ DesktopNotificationPermissionPrompt.prototype = {
         action: SitePermissions.BLOCK,
       },
     ];
-    if (!PrivateBrowsingUtils.isBrowserPrivate(this.browser)) {
+    if (!PrivateBrowsingUtils.isTabContextPrivate(this.browser.ownerGlobal.gBrowser.getTabForBrowser(this.browser))) {
       actions.push({
         label: gBrowserBundle.GetStringFromName("webNotifications.never"),
         accessKey:

--- a/mozilla-release/browser/modules/webrtcUI.jsm
+++ b/mozilla-release/browser/modules/webrtcUI.jsm
@@ -889,7 +889,7 @@ function prompt(aBrowser, aRequest) {
   };
 
   // Don't offer "always remember" action in PB mode.
-  if (!PrivateBrowsingUtils.isBrowserPrivate(aBrowser)) {
+  if (!PrivateBrowsingUtils.isTabContextPrivate(aBrowser.ownerGlobal.gBrowser.getTabForBrowser(aBrowser))) {
     // Disable the permanent 'Allow' action if the connection isn't secure, or for
     // screen/audio sharing (because we can't guess which window the user wants to
     // share without prompting).

--- a/mozilla-release/toolkit/components/extensions/parent/ext-tabs-base.js
+++ b/mozilla-release/toolkit/components/extensions/parent/ext-tabs-base.js
@@ -182,7 +182,7 @@ class TabBase {
    *        @readonly
    */
   get _incognito() {
-    return PrivateBrowsingUtils.isBrowserPrivate(this.browser);
+    return PrivateBrowsingUtils.isTabContextPrivate(this.nativeTab);
   }
 
   /**

--- a/mozilla-release/toolkit/components/passwordmgr/LoginManagerParent.jsm
+++ b/mozilla-release/toolkit/components/passwordmgr/LoginManagerParent.jsm
@@ -329,7 +329,12 @@ var LoginManagerParent = {
     }
 
     function recordLoginUse(login) {
-      if (!target || PrivateBrowsingUtils.isBrowserPrivate(target)) {
+      if (!target) {
+        return;
+      }
+
+      let aTab = target.ownerGlobal.gBrowser.getTabForBrowser(target);
+      if (PrivateBrowsingUtils.isTabContextPrivate(aTab)) {
         // don't record non-interactive use in private browsing
         return;
       }

--- a/mozilla-release/toolkit/components/remotebrowserutils/RemoteWebNavigation.jsm
+++ b/mozilla-release/toolkit/components/remotebrowserutils/RemoteWebNavigation.jsm
@@ -90,9 +90,10 @@ RemoteWebNavigation.prototype = {
         // don't have one or if it's a SystemPrincipal, let's create it with OA
         // inferred from the current context.
         if (!principal || principal.isSystemPrincipal) {
+          let aTab = this._browser.ownerGlobal.gBrowser.getTabForBrowser(this._browser);
           let attrs = {
             userContextId: this._browser.getAttribute("usercontextid") || 0,
-            privateBrowsingId: PrivateBrowsingUtils.isBrowserPrivate(this._browser) ? 1 : 0,
+            privateBrowsingId: PrivateBrowsingUtils.isTabContextPrivate(aTab) ? 1 : 0,
           };
           principal = Services.scriptSecurityManager.createCodebasePrincipal(uri, attrs);
         }

--- a/mozilla-release/toolkit/components/thumbnails/PageThumbs.jsm
+++ b/mozilla-release/toolkit/components/thumbnails/PageThumbs.jsm
@@ -214,8 +214,9 @@ var PageThumbs = {
    *   security checks performed.
    */
   shouldStoreThumbnail(aBrowser, aCallback) {
+    let aTab = aBrowser.ownerGlobal.gBrowser.getTabForBrowser(aBrowser);
     // Don't capture in private browsing mode.
-    if (PrivateBrowsingUtils.isBrowserPrivate(aBrowser)) {
+    if (PrivateBrowsingUtils.isTabContextPrivate(aTab)) {
       aCallback(false);
       return;
     }

--- a/mozilla-release/toolkit/components/viewsource/content/viewSourceUtils.js
+++ b/mozilla-release/toolkit/components/viewsource/content/viewSourceUtils.js
@@ -183,7 +183,8 @@ var gViewSourceUtils = {
           contentType: browser.documentContentType,
           title: browser.contentTitle,
         };
-        data.isPrivate = PrivateBrowsingUtils.isBrowserPrivate(browser);
+        let aTab = browser.ownerGlobal.gBrowser.getTabForBrowser(browser);
+        data.isPrivate = PrivateBrowsingUtils.isTabContextPrivate(aTab);
       }
 
       try {

--- a/mozilla-release/toolkit/modules/PrivateBrowsingUtils.jsm
+++ b/mozilla-release/toolkit/modules/PrivateBrowsingUtils.jsm
@@ -90,10 +90,22 @@ var PrivateBrowsingUtils = {
       // There might be cases when aBrowser.loadContext is not yet (or not anymore)
       // exists for a given aBrowser. As we don't have any other way to know if it's
       // private or not, it's safer to assume it is.
-      //Components.utils.reportError("Browser passed to PrivateBrowsingUtils.isBrowserPrivate " +
-      //                             "does not have loadContext.");
+      Components.utils.reportError("Browser passed to PrivateBrowsingUtils.isBrowserPrivate " +
+                                   "does not have loadContext.");
       return true;
     }
+  },
+
+  isTabContextPrivate(aTab, fromContainer) {
+    if (aTab == null) {
+      return false;
+    }
+
+    if (aTab.linkedBrowser == null || aTab.linkedBrowser.loadContext == null) {
+      return aTab.getAttribute("private") === "true";
+    }
+
+    return this.isBrowserPrivate(aTab.linkedBrowser, fromContainer);
   },
 
   privacyContextFromWindow: function pbu_privacyContextFromWindow(aWindow) {


### PR DESCRIPTION
In this PR I have added a new method "isTabContextPrivate" to PrivateBrowsingUtils module.
The method receives a tab as the first argument and a boolean flag (fromContainer) as the second.

First we try to access the tab's linkedBrowser. If it is null then rely on a value of tab's "private" attribute. Else we examine whether aTab.linkedBrowser has a loadContext, meaning page contents displayed in a window. If it is not there (== null) then rely on the tab's "private" attribute value again.
Otherwise isTabContextPrivate method falls back to isBrowserPrivate implementation. 