### PR TITLE
DB-2319: AFW translation, about:privatebrowsing

### DIFF
--- a/l10n/de/browser/browser/preferences/preferences.ftl
+++ b/l10n/de/browser/browser/preferences/preferences.ftl
@@ -1071,7 +1071,6 @@ forget-mode-enable-checkbox =
     .label = Automatischen Vergessen Modus aktivieren
 forget-mode-explanation1 = Öffnet Websites mit expliziten Inhalten automatisch im Vergessen Modus, so dass sie nicht in der Chronik gespeichert werden.
 forget-mode-explanation2 = Kann im Tab-Kontextmenü (rechter Mausklick auf Tab in Tableiste) für jede Website eingestellt werden.
-forget-mode-explanation3 = Funktioniert nicht in Verbindung mit 'Containers' Add-on.
 forget-mode-note = Hinweis: Für umfassendere Privatsphäre bitte Websites in einem <b>Vergessen Fenster</b> öffnen, weil dort u.a. temporäre Dateien zuverlässiger entfernt werden können.
 forget-mode-learn-more = Mehr erfahren
 

--- a/l10n/de/browser/chrome/browser/browser.properties
+++ b/l10n/de/browser/chrome/browser/browser.properties
@@ -1230,8 +1230,8 @@ confirmationHint.passwordSaved.label = Passwort gespeichert
 # %S will be replaced with brandShortName
 livebookmarkMigration.title                      = Dynamische Lesezeichen von %S
 
-forgetModeNotification.header = Automatisches Vergessen-Modus
+forgetModeNotification.header = Automatischer Vergessen-Modus
 forgetModeNotification.description = Diese Seite wurde in einem Vergessen-Fenster geöffnet. Der Automatische Vergessen-Modus lässt sich in den Browser-Einstellungen ein- und ausschalten.
-forgetModeNotification.link = Lerne mehr über den Vergessen-Modus.
+forgetModeNotification.link = Erfahre mehr über den Vergessen-Modus.
 forgetModeNotification.primaryButton.label = OK
 forgetModeNotification.primaryButton.accesskey = O

--- a/l10n/de/browser/chrome/browser/cliqzPrivateBrowsing.dtd
+++ b/l10n/de/browser/chrome/browser/cliqzPrivateBrowsing.dtd
@@ -12,3 +12,5 @@
   "Dein Internetanbieter oder auch dein Arbeitgeber können weiterhin verfolgen, welche Seiten du besuchst.">
 <!ENTITY cliqzPrivateBrowsing.learnMore
   "Erfahre mehr dazu">
+<!ENTITY cliqzPrivateBrowsing.notForget
+  "Dies ist kein Vergessen-Fenster.">

--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -191,6 +191,9 @@ pref("extensions.update.interval", 86400);  // Check for updates to Extensions a
                                             // Themes every day
 #endif
 
+// CLIQZ-SPECIAL: Enable AFW by default
+pref("browser.privatebrowsing.apt", true);
+
 pref("lightweightThemes.getMoreURL", "https://addons.mozilla.org/%LOCALE%/firefox/themes");
 
 #if defined(MOZ_WIDEVINE_EME)

--- a/mozilla-release/browser/components/BrowserGlue.jsm
+++ b/mozilla-release/browser/components/BrowserGlue.jsm
@@ -2782,9 +2782,6 @@ BrowserGlue.prototype = {
       // This is a new profile, nothing to migrate.
       Services.prefs.setIntPref("browser.migration.version", UI_VERSION);
 
-      // CLIQZ-SPECIAL: Default disabled AFT for new users.
-      Services.prefs.setBoolPref("browser.privatebrowsing.apt", false);
-
       try {
         // New profiles may have existing bookmarks (imported from another browser or
         // copied into the profile) and we want to show the bookmark toolbar for them

--- a/mozilla-release/browser/components/preferences/in-content/privacy.inc.xul
+++ b/mozilla-release/browser/components/preferences/in-content/privacy.inc.xul
@@ -705,7 +705,6 @@
       <description>
         <html:li data-l10n-id="forget-mode-explanation1"/>
         <html:li data-l10n-id="forget-mode-explanation2"/>
-        <html:li data-l10n-id="forget-mode-explanation3"/>
       </description>
     </html:ul>
     <separator class="thin"/>

--- a/mozilla-release/browser/components/privatebrowsing/content-cliqz/aboutPrivateBrowsing.css
+++ b/mozilla-release/browser/components/privatebrowsing/content-cliqz/aboutPrivateBrowsing.css
@@ -44,3 +44,12 @@ a:hover,
 a:active {
   color: #6F6F6F;
 }
+
+.hidden {
+  display: none;
+}
+
+#isNormalWindow {
+  line-height: 100vh;
+  text-align: center;
+}

--- a/mozilla-release/browser/components/privatebrowsing/content-cliqz/aboutPrivateBrowsing.js
+++ b/mozilla-release/browser/components/privatebrowsing/content-cliqz/aboutPrivateBrowsing.js
@@ -1,0 +1,7 @@
+document.addEventListener("DOMContentLoaded", function() {
+  if (!RPMIsWindowPrivate()) {
+    document.getElementById("isNormalWindow").classList.remove("hidden");
+    document.getElementById("isForgetWindow").classList.add("hidden");
+    return;
+  }
+});

--- a/mozilla-release/browser/components/privatebrowsing/content-cliqz/aboutPrivateBrowsing.xhtml
+++ b/mozilla-release/browser/components/privatebrowsing/content-cliqz/aboutPrivateBrowsing.xhtml
@@ -15,20 +15,26 @@
         href="chrome://browser/content/aboutPrivateBrowsing.css"
         />
     <title>&cliqzPrivateBrowsing.title;</title>
+    <script src="chrome://browser/content/aboutPrivateBrowsing.js"></script>
   </head>
 
   <body dir="&locale.dir;" class="private">
-    <div id="header">
-      <p>&cliqzPrivateBrowsing.header;</p>
+    <div id="isNormalWindow" class="hidden">
+      <label>&cliqzPrivateBrowsing.notForget;</label>
     </div>
-    <div id="logo">
-    </div>
-    <div id="main">
-      <p id="explanation">&cliqzPrivateBrowsing.explanation;</p>
-      <p id="note">&cliqzPrivateBrowsing.note;</p>
-      <a href="https://cliqz.com/support/automatic-forget-mode">
-        &cliqzPrivateBrowsing.learnMore;
-      </a>
+    <div id="isForgetWindow">
+      <div id="header">
+        <p>&cliqzPrivateBrowsing.header;</p>
+      </div>
+      <div id="logo">
+      </div>
+      <div id="main">
+        <p id="explanation">&cliqzPrivateBrowsing.explanation;</p>
+        <p id="note">&cliqzPrivateBrowsing.note;</p>
+        <a href="https://cliqz.com/support/automatic-forget-mode">
+          &cliqzPrivateBrowsing.learnMore;
+        </a>
+      </div>
     </div>
   </body>
 </html>

--- a/mozilla-release/browser/components/privatebrowsing/jar.mn
+++ b/mozilla-release/browser/components/privatebrowsing/jar.mn
@@ -10,5 +10,6 @@ browser.jar:
     content/browser/aboutPrivateBrowsing.js               (content/aboutPrivateBrowsing.js)
 #endif
     content/browser/aboutPrivateBrowsing.css              (content-cliqz/aboutPrivateBrowsing.css)
+    content/browser/aboutPrivateBrowsing.js               (content-cliqz/aboutPrivateBrowsing.js)
     content/browser/aboutPrivateBrowsing.xhtml            (content-cliqz/aboutPrivateBrowsing.xhtml)
     content/browser/eraser.svg                            (content-cliqz/eraser.svg)

--- a/mozilla-release/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/mozilla-release/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1185,9 +1185,8 @@ select-bookmark =
 forget-mode-header = Automatic Forget Mode
 forget-mode-enable-checkbox =
     .label = Enable automatic forget mode
-forget-mode-explanation1 = Automatically opens websites with adult content inside a forget tab, so that these websites will not be saved in your history.
+forget-mode-explanation1 = Automatically opens websites with adult content inside a forget window, so that these websites will not be saved in your history.
 forget-mode-explanation2 = Behavior can be changed for each website via the tab context menu (right-click on respective tab in tab bar)
-forget-mode-explanation3 = May not work in combination with 'Containers' add-on."
 forget-mode-note = Note: for improved privacy, it is recommended to always open websites with sensitive content in <b>Forget Windows</b> which allow for more reliable removal of temporary files.
 forget-mode-learn-more = Learn more
 

--- a/mozilla-release/browser/locales/en-US/chrome/browser/cliqzPrivateBrowsing.dtd
+++ b/mozilla-release/browser/locales/en-US/chrome/browser/cliqzPrivateBrowsing.dtd
@@ -12,3 +12,5 @@
   "Note that your internet service provider or your employer at work can still identify websites you visit.">
 <!ENTITY cliqzPrivateBrowsing.learnMore
   "Learn More">
+<!ENTITY cliqzPrivateBrowsing.notForget
+  "This is not a Forget Window.">


### PR DESCRIPTION
This fixes, 
1. DE translations
2. `about:privatebrowsing` opened in normal window was showing forget mode
3. turn on AFW by default for new users. (still need to remove AB tests)