### PR TITLE
DB-2342: hiding language heading at other pages

### DIFF
--- a/mozilla-release/browser/components/preferences/in-content/main.inc.xul
+++ b/mozilla-release/browser/components/preferences/in-content/main.inc.xul
@@ -291,7 +291,7 @@
 </groupbox>
 
 <!-- Languages -->
-<groupbox id="languagesGroup" data-category="paneGeneral">
+<groupbox id="languagesGroup" data-category="paneGeneral" hidden="true">
   <label><html:h2 data-l10n-id="language-header"/></label>
 
 <!-- CLIQZ-SPECIAL, DB-2146: temporarily hide Language section


### PR DESCRIPTION
Putting back hidden true, FF deals all the `groupbox` hide/show by `data-category` attribute
so lets go FF way 