### PR TITLE
Update default cookie policy to reject from unvisited

### DIFF
--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -1618,7 +1618,7 @@ pref("browser.ping-centre.production.endpoint", "");
 pref("media.gmp-provider.enabled", true);
 
 // Enable blocking access to storage from tracking resources by default.
-pref("network.cookie.cookieBehavior", 4 /* BEHAVIOR_REJECT_TRACKER */);
+pref("network.cookie.cookieBehavior", 3 /* BEHAVIOR_REJECT_UNVISITED */);
 #ifdef EARLY_BETA_OR_EARLIER
   // Enable fingerprinting blocking by default only in nightly and early beta.
   pref("privacy.trackingprotection.fingerprinting.enabled", true);

--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -1618,7 +1618,7 @@ pref("browser.ping-centre.production.endpoint", "");
 pref("media.gmp-provider.enabled", true);
 
 // Enable blocking access to storage from tracking resources by default.
-pref("network.cookie.cookieBehavior", 3 /* BEHAVIOR_REJECT_UNVISITED */);
+pref("network.cookie.cookieBehavior", 3 /* BEHAVIOR_LIMIT_FOREIGN */);
 #ifdef EARLY_BETA_OR_EARLIER
   // Enable fingerprinting blocking by default only in nightly and early beta.
   pref("privacy.trackingprotection.fingerprinting.enabled", true);


### PR DESCRIPTION
As discussed with @tsl143 , the reject tracker policy is currently not working properly as the tracking protection code has been removed. This change switches to a more protective default until we can implement a reject tracker policy using our own tracking list.