### PR TITLE
falling back to processcount 8 as Firefox

### DIFF
--- a/cliqz.cfg
+++ b/cliqz.cfg
@@ -41,9 +41,6 @@ lockPref("distribution.version", AppConstants.MOZ_APP_VERSION_DISPLAY);
 
 pref("browser.uitour.enabled", false);
 
-// Use up to 4 processes for webpages rendering (e10s-multi)
-pref("dom.ipc.processCount", 4);
-
 // Disable Safe Mode trigger on start
 lockPref("toolkit.startup.max_resumed_crashes", -1);
 


### PR DESCRIPTION
Firefox already uses max 8 process, so we do not need to restrict this to 4

here - https://github.com/cliqz-oss/browser-f/blob/master/mozilla-release/modules/libpref/init/all.js#L2673