### PR TITLE
DB-2374: fixing border for navigator-toolbox

### DIFF
--- a/mozilla-release/browser/themes/osx/cliqz/theme.css
+++ b/mozilla-release/browser/themes/osx/cliqz/theme.css
@@ -65,8 +65,6 @@
   /* NAVIGATION TOOLBAR */
   /* Line on the bottom of the nav-bar/toolbar */
   /* Forget mode urlbar */
-  box-shadow: 0 1px 1px 0px rgba(204, 204, 204, 0.4);
-  border-bottom: none;
 }
 #navigator-toolbox #TabsToolbar {
   /* Customize tabs toolbar background color for light theme */

--- a/mozilla-release/browser/themes/windows/cliqz/theme.css
+++ b/mozilla-release/browser/themes/windows/cliqz/theme.css
@@ -211,12 +211,6 @@ toolbar .toolbarbutton-1 > .toolbarbutton-icon {
 #navigator-toolbox #PersonalToolbar[brighttext=true] {
   border-top-color: #626262;
 }
-#navigator-toolbox:after {
-  box-shadow: rgba(0, 0, 0, 0.19) 0 -2px 1px 3px;
-  border-bottom: unset;
-  -moz-appearance: unset;
-  height: unset;
-}
 #navigator-toolbox:-moz-window-inactive:after {
   box-shadow: rgba(0, 0, 0, 0.19) 0 -2px 1px 3px;
 }


### PR DESCRIPTION
In this fix, we are resorting to default behavior of firefox wrt to border below the URLbar for mac and windows.

this is dealt by `#navigator-toolbox:after` element.