### PR TITLE
Addresses browser crash when built for Linux.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,100 +1,83 @@
-# Dockerfile used for regular linux builds.
-FROM ubuntu:16.04
+# Ubuntu:19.10 on 16-01-2020 at 3:15 am
+FROM ubuntu:19.10@sha256:9e9387cd5380eb96ace218a2f85ed25ac75563cd170f91852a73aefda6fa7834
 
-RUN apt-get update && apt-get install -y \
-  gcc \
+# NOTE: is this the issue? https://bugzilla.mozilla.org/show_bug.cgi?id=1594686
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# From: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites
+# Additions from bootstrap.py + dependencies for custom ppa.
+RUN apt-get update && apt-get install --yes \
   alien \
-  fakeroot \
-  rpm \
-  git \
-  python-dev \
-  python-pip \
-  desktop-file-utils \
-  wget \
-  sudo \
-  libgstreamer1.0-dev \
-  libgstreamer-plugins-base1.0-dev \
-  libgstreamer-plugins-base0.10-0 \
-  libgstreamer0.10-0 \
-  libgstreamer0.10-dev \
+  apt-transport-https \
+  apt-utils \
+  aptly \
   autoconf2.13 \
+  awscli \
+  binutils-avr \
   build-essential \
   ccache \
-  python-dev \
-  python-pip \
-  python-setuptools \
-  unzip \
-  uuid \
-  zip \
+  clang \
+  desktop-file-utils \
+  fakeroot \
+  hunspell-en-us \
   libasound2-dev \
   libcurl4-openssl-dev \
   libdbus-1-dev \
   libdbus-glib-1-dev \
-  libgconf2-dev \
+  libfontconfig1-dev \
+  libfreetype6-dev \
+  libgl1-mesa-dev \
+  libgstreamer-plugins-base1.0-dev \
+  libgstreamer1.0-dev \
   libgtk-3-dev \
   libgtk2.0-dev \
-  libiw-dev \
   libnotify-dev \
   libpulse-dev \
+  libpython-dev \
   libx11-xcb-dev \
   libxt-dev \
-  mesa-common-dev \
+  make \
+  nasm \
+  nodejs \
+  pkg-config \
   python-dbus \
+  python-dev \
+  python-pip \
+  python-setuptools \
+  rpm \
+  sudo \
+  unzip \
+  uuid \
+  wget \
   xvfb \
   yasm \
-  apt-transport-https
+  zip
 
-RUN pip install awscli
+ENV RUSTUP_HOME=/usr/local/rustup \
+  CARGO_HOME=/usr/local/cargo \
+  PATH=/usr/local/cargo/bin:$PATH
 
-RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list; \
-  apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C; \
-  apt-get update; \
-  apt-get install aptly -y
+RUN wget "https://static.rust-lang.org/rustup/archive/1.21.1/x86_64-unknown-linux-gnu/rustup-init" \
+ && echo "ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b *rustup-init" | sha256sum -c - \
+ && chmod +x rustup-init \
+ && ./rustup-init -y --no-modify-path --default-toolchain 1.39.0 \
+ && rm rustup-init \
+ && chmod -R a+w $RUSTUP_HOME $CARGO_HOME \
+ && rustup --version \
+ && cargo --version \
+ && rustc --version
 
-  ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
-
-RUN echo "deb http://ppa.launchpad.net/mercurial-ppa/releases/ubuntu xenial main" > /etc/apt/sources.list.d/mercurial.list; \
-  apt-key adv --keyserver pool.sks-keyservers.net --recv-keys 41BD8711B1F0EC2B0D85B91CF59CE3A8323293EE; \
-  apt-get update; \
-  apt-get install mercurial -y
-
-RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-RUN echo "deb https://deb.nodesource.com/node_10.x xenial main" > /etc/apt/sources.list.d/nodesource.list; \
-  apt-get update; \
-  apt-get install -y nodejs
-
-RUN set -eux; \
-    \
-# this "case" statement is generated via "update.sh"
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
-        amd64) rustArch='x86_64-unknown-linux-gnu'; rustupSha256='5a38dbaf7ab2e4335a3dfc42698a5b15e7167c93b0b06fc95f53c1da6379bf1a' ;; \
-        armhf) rustArch='armv7-unknown-linux-gnueabihf'; rustupSha256='67a98a67f7f7bf19c5cde166499acb8299f2f8fa88c155093df53b66da1f512a' ;; \
-        arm64) rustArch='aarch64-unknown-linux-gnu'; rustupSha256='82fe368c4ebf1683d57e137242793a4417042639aace8bd514601db7d79d3645' ;; \
-        i386) rustArch='i686-unknown-linux-gnu'; rustupSha256='7a1c085591f6c1305877919f8495c04a1c97546d001d1357a7a879cedea5afbb' ;; \
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-    esac; \
-    url="https://static.rust-lang.org/rustup/archive/1.7.0/${rustArch}/rustup-init"; \
-    wget "$url"; \
-    echo "${rustupSha256} *rustup-init" | sha256sum -c -; \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --default-toolchain 1.37.0; \
-    rm rustup-init; \
-    chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
-    rustup --version; \
-    cargo --version; \
-    rustc --version
-
-RUN cargo install --version 0.9.1 cbindgen
+RUN cargo install --version 0.12.2 cbindgen
 
 ARG uid
 ARG gid
 ARG user
 ENV SHELL=/bin/bash
 
-RUN groupadd $user -g $gid && useradd -ms /bin/bash $user -u $uid -g $gid && usermod -aG sudo $user
+RUN groupadd $user -g $gid \
+ && useradd -ms /bin/bash $user -u $uid -g $gid \
+ && usermod -aG sudo $user
 
 # Enable passwordless sudo for users under the "sudo" group
 RUN sed -i.bkp -e \
@@ -104,31 +87,5 @@ RUN sed -i.bkp -e \
 RUN mkdir /builds
 
 USER $user
-ENV CLANG_HOME /home/$user/clang/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04/
-ENV GCC_VERSION=6.0.0
-ENV CXX=$CLANG_HOME/bin/clang++
-ENV CC=$CLANG_HOME/bin/clang
-ENV LLVM_CONFIG=$CLANG_HOME/bin/llvm-config
+
 SHELL ["/bin/bash", "-l", "-c"]
-
-#Install CLang
-RUN mkdir -p /home/$user/clang; \
-    cd /home/$user/clang; \
-    wget --output-document=clang.tar.xz --quiet "https://repository.cliqz.com/dist/android/artifacts/clang/clang%2Bllvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz"; \
-    tar xf clang.tar.xz; \
-    echo 'export PATH=$CLANG_HOME/bin:$PATH' >> ~/.bashrc; \
-    echo 'export LD_LIBRARY_PATH=$CLANG_HOME/lib:LD_LIBRARY_PATH' >> ~/.bashrc; \
-    ln -s /usr/include include; \
-    ln -s /usr/bin bin;\
-    mkdir -p lib/gcc/x86_64-linux-gnu/; \
-    cd lib/gcc/x86_64-linux-gnu/; \
-    ln -s /usr/lib/gcc/x86_64-linux-gnu/$GCC_VERSION $GCC_VERSION
-
-#Install nasm 2.13
-RUN mkdir -p /home/$user/nasm; \
-    cd /home/$user/nasm; \
-    wget --output-document=nasm.tar.xz --quiet "https://www.nasm.us/pub/nasm/releasebuilds/2.13.03/nasm-2.13.03.tar.xz"; \
-    tar xf nasm.tar.xz; \
-    cd nasm-2.13.03; \
-    sh configure; \
-    sudo make install

--- a/mozilla-release/browser/config/cliqz.mozconfig
+++ b/mozilla-release/browser/config/cliqz.mozconfig
@@ -29,3 +29,17 @@ if echo $OSTYPE | grep -q "msys"; then
   ac_add_options --enable-warnings-as-errors
   ac_add_options --enable-jemalloc
 fi
+
+export CC='clang --target=x86_64-unknown-linux-gnu'
+export CXX='clang++ --target=x86_64-unknown-linux-gnu'
+
+ac_add_options --enable-hardening
+ac_add_options --enable-release
+ac_add_options --enable-optimize
+ac_add_options --enable-rust-simd
+
+# NOTE: Link time optimizations should be supported on Linux but are currently
+# disabled because it requires some exta care. See here for more details:
+# https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/firefox#n107
+# In particular, some compilation flag needs to be disabled.
+# ac_add_options --enable-lto


### PR DESCRIPTION
Fixes #1435
Fixes #1434

The issue seems to be this one: https://bugzilla.mozilla.org/show_bug.cgi?id=1600467,
where the version 6.x of clang, which is also the one shipped with Ubuntu 18.04,
is known to have "miscompilation issues" when applied to the Firefox codebase
(see: https://bugzilla.mozilla.org/show_bug.cgi?id=1594686).

Because it took a while to realize that the issue was from clang, I iterated on
both the Dockerfile and cliqz.mozconfig during the investigation. This commit
changes a bit more than what is strictly needed to fix the issue, and contains
a refreshed Dockerfile. It was both updated and simplified, mostly because the
base image used now ships with more recent versions of various packages that
we need (Ubuntu 19.10).

Last but not least, I propose a few additions to the Linux compilation
configuration, mostly related to security and performance:

  * --enable-hardening (this one is likely enabled by default already)
  * --enable-release (triggers rustc optimization flags)
  * --enable-optimize (might already be set by default)
  * --enable-rust-simd (enable extra optimizations for rust code)