### PR TITLE
linux: enable rust-simd compile flag

### DIFF
--- a/mozilla-release/browser/config/cliqz.mozconfig
+++ b/mozilla-release/browser/config/cliqz.mozconfig
@@ -30,14 +30,12 @@ if echo $OSTYPE | grep -q "msys"; then
   ac_add_options --enable-jemalloc
 fi
 
-# if test `uname -s` = "Linux"; then
-  # NOTE: We will consider enabling this option as well in the future, but this
-  # should be tested on beta first.
-  # ac_add_options --enable-rust-simd
+if test `uname -s` = "Linux"; then
+  ac_add_options --enable-rust-simd
 
   # NOTE: Link time optimizations should be supported on Linux but are currently
   # disabled because it requires some exta care. See here for more details:
   # https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/firefox#n107
   # In particular, some compilation flag needs to be disabled.
   # ac_add_options --enable-lto
-# fi
+fi

--- a/mozilla-release/browser/config/cliqz.mozconfig
+++ b/mozilla-release/browser/config/cliqz.mozconfig
@@ -10,6 +10,7 @@ ac_add_options --enable-crashreporter
 ac_add_options --enable-js-shell
 ac_add_options --enable-update-channel=${MOZ_UPDATE_CHANNEL}
 ac_add_options --enable-release
+ac_add_options --enable-rust-simd
 ac_add_options --with-mozilla-api-keyfile=$ROOT_PATH/mozilla-desktop-geoloc-api.key
 ac_add_options --with-google-safebrowsing-api-keyfile=$ROOT_PATH/google-desktop-api.key
 ac_add_options "MOZ_ALLOW_LEGACY_EXTENSIONS=1"
@@ -30,12 +31,10 @@ if echo $OSTYPE | grep -q "msys"; then
   ac_add_options --enable-jemalloc
 fi
 
-if test `uname -s` = "Linux"; then
-  ac_add_options --enable-rust-simd
-
-  # NOTE: Link time optimizations should be supported on Linux but are currently
-  # disabled because it requires some exta care. See here for more details:
-  # https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/firefox#n107
-  # In particular, some compilation flag needs to be disabled.
-  # ac_add_options --enable-lto
-fi
+# if test `uname -s` = "Linux"; then
+#   # NOTE: Link time optimizations should be supported on Linux but are currently
+#   # disabled because it requires some exta care. See here for more details:
+#   # https://git.archlinux.org/svntogit/packages.git/tree/trunk/PKGBUILD?h=packages/firefox#n107
+#   # In particular, some compilation flag needs to be disabled.
+#   # ac_add_options --enable-lto
+# fi


### PR DESCRIPTION
This PR enables `rust-simd` compile flag which could bring some performance improvement. I already tested building the browser with this option and will now check if the resulting binary runs fine on different Linux distributions.