### PR TITLE
Fix Dockerfile for Linux build

### DIFF
--- a/cliqz_env.sh
+++ b/cliqz_env.sh
@@ -122,6 +122,9 @@ fi
 # set our own BUILD_ID in new build system, must be specified in format %Y%m%d%H%M%S
 export MOZ_BUILD_DATE=$CQZ_BUILD_ID
 
+export MOZ_SOURCE_REPO=https://github.com/cliqz-oss/browser-f
+export MOZ_SOURCE_CHANGESET=$CQZ_BUILD_ID
+
 # set path on S3 with BUILD_ID. From this path we take *.xpi and upload
 # build artifacts back (to locale folder, same as FF)
 export S3_UPLOAD_PATH=`echo dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$MOZ_BUILD_DATE`
@@ -141,4 +144,3 @@ export CQZ_ADULT_DOMAINS_BF=../adult-domains.bin
 
 export ROOT_PATH=$PWD
 export SHELL=$SHELL
-

--- a/cliqz_env.sh
+++ b/cliqz_env.sh
@@ -122,9 +122,6 @@ fi
 # set our own BUILD_ID in new build system, must be specified in format %Y%m%d%H%M%S
 export MOZ_BUILD_DATE=$CQZ_BUILD_ID
 
-export MOZ_SOURCE_REPO=https://github.com/cliqz-oss/browser-f
-export MOZ_SOURCE_CHANGESET=$CQZ_BUILD_ID
-
 # set path on S3 with BUILD_ID. From this path we take *.xpi and upload
 # build artifacts back (to locale folder, same as FF)
 export S3_UPLOAD_PATH=`echo dist/$CQZ_RELEASE_CHANNEL/$CQZ_VERSION/$MOZ_BUILD_DATE`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,11 +62,11 @@ RUN apt-get update && apt-get install --yes \
   yasm \
   zip
 
-# Install clang + llvm version 10
+# Install clang + llvm version 9
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
- && add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" \
+ && add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main" \
  && apt-get update \
- && apt-get install --yes clang-10 lldb-10 lld-10 clangd-10 libclang-10-dev
+ && apt-get install --yes clang-9 lldb-9 lld-9 clangd-9 libclang-9-dev
 
 # Install awscli
 RUN pip install awscli==1.17.5
@@ -83,7 +83,7 @@ RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add
  && apt-get update \
  && apt-get install --yes nodejs
 
-# Install Rust toolchain version 1.41.0
+# Install Rust toolchain version 1.39.0
 ENV RUSTUP_HOME=/usr/local/rustup \
   CARGO_HOME=/usr/local/cargo \
   PATH=/usr/local/cargo/bin:$PATH
@@ -91,7 +91,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN wget "https://static.rust-lang.org/rustup/archive/1.21.1/x86_64-unknown-linux-gnu/rustup-init" \
  && echo "ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b *rustup-init" | sha256sum -c - \
  && chmod +x rustup-init \
- && ./rustup-init -y --no-modify-path --default-toolchain 1.41.0 \
+ && ./rustup-init -y --no-modify-path --default-toolchain 1.39.0 \
  && rm rustup-init \
  && chmod -R a+w $RUSTUP_HOME $CARGO_HOME \
  && rustup --version \
@@ -128,7 +128,7 @@ RUN mkdir /builds
 
 USER $user
 
-ENV CC="clang-10 --target=x86_64-unknown-linux-gnu"
-ENV CXX="clang++-10 --target=x86_64-unknown-linux-gnu"
+ENV CC="clang-9 --target=x86_64-unknown-linux-gnu"
+ENV CXX="clang++-9 --target=x86_64-unknown-linux-gnu"
 
 SHELL ["/bin/bash", "-l", "-c"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
-# Ubuntu:16.04 on 16-01-2020 at 3:14 am
-FROM ubuntu:16.04@sha256:e60a002052d1a073f3212f3732cff8abc7997939c731850e6960eb94a244c406
+# Ubuntu:18.04 on 16-01-2020 at 3:14 am
+FROM ubuntu:18.04@sha256:bc025862c3e8ec4a8754ea4756e33da6c41cba38330d7e324abd25c8e0b93300
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -62,28 +62,28 @@ RUN apt-get update && apt-get install --yes \
   yasm \
   zip
 
-# Install clang + llvm version 9
+# Install clang + llvm version 10
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - \
- && add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" \
+ && add-apt-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main" \
  && apt-get update \
- && apt-get install --yes clang-9 lldb-9 lld-9 clangd-9 libclang-9-dev
+ && apt-get install --yes clang-10 lldb-10 lld-10 clangd-10 libclang-10-dev
 
 # Install awscli
 RUN pip install awscli==1.17.5
 
 # Install aptly for ppa management
 RUN echo "deb http://repo.aptly.info/ squeeze main" > /etc/apt/sources.list.d/aptly.list \
- && apt-key adv --keyserver pool.sks-keyservers.net --recv-keys ED75B5A4483DA07C \
+ && wget -qO - https://www.aptly.info/pubkey.txt | apt-key add - \
  && apt-get update \
  && apt-get install aptly --yes
 
 # Install Node.js (LTS = 12.x)
 RUN wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
- && echo "deb https://deb.nodesource.com/node_12.x xenial main" > /etc/apt/sources.list.d/nodesource.list \
+ && echo "deb https://deb.nodesource.com/node_12.x bionic main" > /etc/apt/sources.list.d/nodesource.list \
  && apt-get update \
  && apt-get install --yes nodejs
 
-# Install Rust toolchain version 1.39.0
+# Install Rust toolchain version 1.41.0
 ENV RUSTUP_HOME=/usr/local/rustup \
   CARGO_HOME=/usr/local/cargo \
   PATH=/usr/local/cargo/bin:$PATH
@@ -91,7 +91,7 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 RUN wget "https://static.rust-lang.org/rustup/archive/1.21.1/x86_64-unknown-linux-gnu/rustup-init" \
  && echo "ad1f8b5199b3b9e231472ed7aa08d2e5d1d539198a15c5b1e53c746aad81d27b *rustup-init" | sha256sum -c - \
  && chmod +x rustup-init \
- && ./rustup-init -y --no-modify-path --default-toolchain 1.39.0 \
+ && ./rustup-init -y --no-modify-path --default-toolchain 1.41.0 \
  && rm rustup-init \
  && chmod -R a+w $RUSTUP_HOME $CARGO_HOME \
  && rustup --version \
@@ -128,7 +128,7 @@ RUN mkdir /builds
 
 USER $user
 
-ENV CC="clang-9 --target=x86_64-unknown-linux-gnu"
-ENV CXX="clang++-9 --target=x86_64-unknown-linux-gnu"
+ENV CC="clang-10 --target=x86_64-unknown-linux-gnu"
+ENV CXX="clang++-10 --target=x86_64-unknown-linux-gnu"
 
 SHELL ["/bin/bash", "-l", "-c"]

--- a/mozilla-release/toolkit/mozapps/installer/upload-files.mk
+++ b/mozilla-release/toolkit/mozapps/installer/upload-files.mk
@@ -181,8 +181,7 @@ ifeq ($(OS_ARCH), Linux)
 		--define 'moz_numeric_app_version $(MOZ_NUMERIC_APP_VERSION)' \
 		--define 'moz_rpm_release $(MOZ_RPM_RELEASE)' \
 		--define 'buildid $(BUILDID)' \
-		--define 'moz_source_repo $(shell awk '$$2 == "MOZ_SOURCE_REPO" {print $$3}' $(DEPTH)/source-repo.h)' \
-		--define 'moz_source_stamp $(shell awk '$$2 == "MOZ_SOURCE_STAMP" {print $$3}' $(DEPTH)/source-repo.h)' \
+		--define 'moz_source_repo https://github.com/cliqz-oss/browser-f' \
 		--define 'moz_branding_directory $(topsrcdir)/$(MOZ_BRANDING_DIRECTORY)' \
 		--define '_topdir $(RPMBUILD_TOPDIR)' \
 		--define '_rpmdir $(RPMBUILD_RPMDIR)' \


### PR DESCRIPTION
Build of Cliqz on Linux started failing a few days ago. It seems to be due to an incompatibility with `libc` that is shipped by default with Ubuntu 16.04 which we used until now to compile and source code from upstream Firefox/build toolchain. The reason we picked such an old version of Ubuntu to compile Cliqz at the time was the following:

* The `libc` version is bound to the linux distribution (and versions shipping from newer distributions usually introduce breaking changes).
* Version of `libc` will determine the compatibility of Cliqz for older systems (Cliqz compiled with `libc` from Ubuntu 18.04 will not be able to run on Ubuntu 16.04).

Hence, we picked the oldest version we could, so that Cliqz can run on as many distributions as possible. It would be possible to have custom building pipelines for each distributions but this is not a cost we can pay at the moment as it would introduce tremendous complexity compared to the "simple" setup we have now, thus we need to keep a single build for multi-linux support.

This PR fixes building on Linux, but will also force us to drop compatibility with some older systems (some further testing is required to have the final list but likely Ubuntu 16.04, some older Debian version, etc.). This compatibility could be re-introduced by using something by Flatpak/Snap though, which would likely bundle their own libraries (i.e. `libc`).

Cc @philipp-classen @alver-cliqz 