### PR TITLE
DB-2430: remove redundant resetSearchState | UrlbarInput.jsm

### DIFF
--- a/mozilla-release/browser/components/urlbar/UrlbarInput.jsm
+++ b/mozilla-release/browser/components/urlbar/UrlbarInput.jsm
@@ -2071,8 +2071,6 @@ class UrlbarInput {
   }
 
   _on_TabSelect(event) {
-    this._resetSearchState();
-
     // CLIQZ-SPECIAL: DB-2272
     // There might be a case when opening and selecting a new tab
     // results in displaying the gradient mask-image on url bar.


### PR DESCRIPTION
We do not have to call this this._resetSearchState method if tab changed.
Because this method gets triggered within this._afterTabSelectAndFocusChange function after a proper check.