### PR TITLE
DB-2433: allowing experiments on release builds for temporary extension

### DIFF
--- a/mozilla-release/browser/config/cliqz.mozconfig
+++ b/mozilla-release/browser/config/cliqz.mozconfig
@@ -13,12 +13,12 @@ ac_add_options --enable-release
 ac_add_options --enable-rust-simd
 ac_add_options --with-mozilla-api-keyfile=$ROOT_PATH/mozilla-desktop-geoloc-api.key
 ac_add_options --with-google-safebrowsing-api-keyfile=$ROOT_PATH/google-desktop-api.key
-ac_add_options "MOZ_ALLOW_LEGACY_EXTENSIONS=1"
 
 export MOZ_APP_PROFILE=CLIQZ
 export MOZ_AUTOMATION_UPLOAD=1
 export MOZ_TELEMETRY_REPORTING=1
-export MOZ_ADDON_SIGNING=1
+# MOZ_REQUIRE_SIGNING flag is added to make sure no persistent addon is installed without signature
+# this flag overrides xpinstall.signatures.required, look AddonSettings.jsm
 export MOZ_REQUIRE_SIGNING=1
 export MOZ_PACKAGE_JSSHELL=1
 # safeguard against someone forgetting to re-set EARLY_BETA_OR_EARLIER in

--- a/mozilla-release/toolkit/mozapps/extensions/internal/AddonSettings.jsm
+++ b/mozilla-release/toolkit/mozapps/extensions/internal/AddonSettings.jsm
@@ -85,6 +85,7 @@ if (Cu.isInAutomation) {
  *
  * Official releases ignore this preference.
  */
+#if 0
 if (
   !AppConstants.MOZ_REQUIRE_SIGNING ||
   AppConstants.NIGHTLY_BUILD ||
@@ -96,6 +97,23 @@ if (
     "EXPERIMENTS_ENABLED",
     PREF_ALLOW_EXPERIMENTS,
     true
+  );
+} else {
+  makeConstant("EXPERIMENTS_ENABLED", false);
+}
+#endif
+
+// CLIQZ-SPECIAL: We always have MOZ_REQUIRE_SIGNING defined
+// so there will be no unsigned addon installation allowed
+// Unsigned addons can only be installed as temporary addon.
+// We need to allow experiments in temporary addons
+// so that our extension test pipelines work.
+if (AppConstants.MOZ_REQUIRE_SIGNING) {
+  XPCOMUtils.defineLazyPreferenceGetter(
+    AddonSettings,
+    "EXPERIMENTS_ENABLED",
+    PREF_ALLOW_EXPERIMENTS,
+    false
   );
 } else {
   makeConstant("EXPERIMENTS_ENABLED", false);


### PR DESCRIPTION
`MOZ_ALLOW_LEGACY_EXTENSIONS` - is used no where FF discarded in FF 74
`MOZ_ADDON_SIGNING` is also not used anywhere in project (@alver-cliqz please confirm)

