### PR TITLE
Revert "Update default cookie policy to reject from unvisited (#1401)"

### DIFF
--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -1590,7 +1590,7 @@ pref("media.gmp-provider.enabled", true);
 // Enable blocking access to storage from tracking resources by default.
 // pref("network.cookie.cookieBehavior", 4 /* BEHAVIOR_REJECT_TRACKER */);
 // CLIQZ-SPECIAL
-pref("network.cookie.cookieBehavior", 3 /* BEHAVIOR_LIMIT_FOREIGN */);
+pref("network.cookie.cookieBehavior", 4 /* BEHAVIOR_REJECT_TRACKER */);
 
 // Enable fingerprinting blocking by default for all channels, only on desktop.
 // CLIQZ-MERGE - check if we can remove beta check (Firefox get this unconditionoial)


### PR DESCRIPTION
This reverts commit 246bbde261f2102c205b69c6461ffabf9cd4b061.

As discussed with @konark-cliqz, this setting was causing some breakage that cannot be fixed by just whitelisting in control-center. In order to minimise breakage we will revert the setting, and the extension's anti-tracking features should catch cookies set via dom apis.