### PR TITLE
DB-2439: switch off corroborator and temporary downgrade TLS to 1

### DIFF
--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -1954,7 +1954,8 @@ pref("identity.fxaccounts.service.sendLoginUrl", "https://send.firefox.com/login
 pref("identity.fxaccounts.service.monitorLoginUrl", "https://monitor.firefox.com/");
 
 // Check bundled omni JARs for corruption.
-pref("corroborator.enabled", true);
+// CLIQZ-SPECIAL: don't use yet, must be carefully checked first
+pref("corroborator.enabled", false);
 
 // Toolbox preferences
 pref("devtools.toolbox.footer.height", 250);

--- a/mozilla-release/modules/libpref/init/all.js
+++ b/mozilla-release/modules/libpref/init/all.js
@@ -19,7 +19,8 @@
 // improves readability, particular for conditional blocks that exceed a single
 // screen.
 
-pref("security.tls.version.min", 3);
+// CLIQZ-SPECIAL: temporary use version 1
+pref("security.tls.version.min", 1);
 pref("security.tls.version.max", 4);
 pref("security.tls.version.enable-deprecated", false);
 pref("security.tls.version.fallback-limit", 4);


### PR DESCRIPTION

Findings:
corroborator verifies the signature of omni.ja files, this uses addons certificate to verify