### PR TITLE
DB-2456: remove unecessary functions from Cliqzresource

### DIFF
--- a/mozilla-release/browser/app/profile/firefox.js
+++ b/mozilla-release/browser/app/profile/firefox.js
@@ -1356,7 +1356,10 @@ pref("browser.newtabpage.activity-stream.discoverystream.personalization.modelKe
 pref("trailhead.firstrun.branches", "");
 
 // Separate about welcome
-pref("browser.aboutwelcome.enabled", false);
+pref("browser.aboutwelcome.enabled", false); // ALWAYS FALSE
+// CLIQZ-SPECIAL: always make sure this remains false,
+// we do not want separate welcome page
+
 // See Console.jsm LOG_LEVELS for all possible values
 pref("browser.aboutwelcome.log", "warn");
 

--- a/mozilla-release/browser/base/content/browser.js
+++ b/mozilla-release/browser/base/content/browser.js
@@ -1555,7 +1555,6 @@ function _loadURI(browser, uri, params = {}) {
   let loadFlags =
     params.loadFlags || params.flags || Ci.nsIWebNavigation.LOAD_FLAGS_NONE;
 
-  uri = CliqzResources.matchUrlByString(uri);
   if (CliqzResources.isCliqzPage(uri)) {
     loadFlags = loadFlags | Ci.nsIWebNavigation.LOAD_FLAGS_BYPASS_HISTORY;
   }

--- a/mozilla-release/browser/components/CliqzResources.jsm
+++ b/mozilla-release/browser/components/CliqzResources.jsm
@@ -34,17 +34,6 @@ const getWebExtPrefix = function(extensionId = DEFAULT_EXTENSION_ID) {
 };
 
 const CliqzResources = {
-  matchUrlByString: function(key) {
-    switch (key) {
-      case 'chrome://cliqz/content/onboarding-v3/index.html':
-      case 'resource://cliqz/freshtab/home.html':
-      case 'about:welcome':
-        return 'about:home';
-
-      default:
-        return key;
-    }
-  },
   // CLIQZ-SPECIAL: we do not need BROWSER_NEW_TAB_URL check as we never change it
   // return gInitialPages.includes(url) || url == BROWSER_NEW_TAB_URL;
   isInitialPage: function(url) {
@@ -67,20 +56,4 @@ const CliqzResources = {
   },
   whatIstheURL: (u) => `${getWebExtPrefix()}/modules/${u}`,
   getExtensionURL: (path, extensionId = DEFAULT_EXTENSION_ID) => `${getWebExtPrefix(extensionId)}${path}`,
-  getUrlWithProperExtentionId: function(url = '') {
-    if (!url || typeof url != 'string') {
-      return url;
-    }
-
-    if (url.indexOf('moz-extension://') !== 0) {
-      return url;
-    }
-
-    let outerParts = url.split('moz-extension://');
-    let innerParts = outerParts[1].split('/');
-    innerParts[0] = getWebExtId();
-
-    outerParts[1] = innerParts.join('/');
-    return outerParts.join('moz-extension://');
-  },
 };


### PR DESCRIPTION
We got rid of `matchUrlByString` as we do not have any chance of legacy extension, additionally FF introduced a way to avoid `about:welcome` and use `about:home` instead.