### PR TITLE
DB:2459 fixing focus of url bar edge case

### DIFF
--- a/mozilla-release/browser/base/content/utilityOverlay.js
+++ b/mozilla-release/browser/base/content/utilityOverlay.js
@@ -81,6 +81,9 @@ var gBidiUI = false;
  */
 function isBlankPageURL(aURL) {
   return (
+    // CLIQZ-SPECIAL: covering corner case when
+    // uri is undefined from sessionstore.
+    !aURL ||
     aURL == "about:blank" ||
     aURL == "about:home" ||
     aURL == "about:welcome" ||

--- a/mozilla-release/browser/components/sessionstore/SessionStore.jsm
+++ b/mozilla-release/browser/components/sessionstore/SessionStore.jsm
@@ -4829,7 +4829,7 @@ var SessionStoreInternal = {
     });
 
     // Focus the tab's content area.
-    if (aTab.selected && !window.isBlankPageURL(uri) && !String(uri).startsWith("moz-extension")) {
+    if (aTab.selected && !window.isBlankPageURL(uri)) {
       browser.focus();
     }
   },


### PR DESCRIPTION
Since we now use default FF way to handle home/newtab page, we do not need this fix.
`isBlankPageURL` will take care of cliqz extension URL (`BROWSER_NEW_TAB_URL` === freshtab URL)